### PR TITLE
Update schema structs and add UUID as primary and foreign keys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.16.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
+	github.com/google/uuid v1.4.0
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.6 // indirect
 	github.com/leodido/go-urn v1.2.4 // indirect

--- a/src/models/schemas/Address.go
+++ b/src/models/schemas/Address.go
@@ -1,10 +1,12 @@
 package schemas
 
+import "github.com/google/uuid"
+
 type Address struct {
-	ID       int    `json:"id"`
-	Street   string `json:"street"`
-	Streetnr string `json:"streetnr"`
-	Zipcode  string `json:"zipcode"`
-	City     string `json:"city"`
-	Country  string `json:"country"`
+	Id       *uuid.UUID `json:"id"`
+	Street   string     `json:"street"`
+	Streetnr string     `json:"streetnr"`
+	Zipcode  string     `json:"zipcode"`
+	City     string     `json:"city"`
+	Country  string     `json:"country"`
 }

--- a/src/models/schemas/CinemalHall.go
+++ b/src/models/schemas/CinemalHall.go
@@ -1,18 +1,20 @@
 package schemas
 
+import "github.com/google/uuid"
+
 type CinemaHall struct {
-	ID       int    `json:"id"`
-	Name     string `json:"name"`
-	Capacity int    `json:"capacity"`
-	Seats    []Seat `json:"seats"`
+	Id        *uuid.UUID `json:"id"`
+	Name      string     `json:"name"`
+	Capacity  int        `json:"capacity"`
+	TheatreId *uuid.UUID `json:"theatreId"`
 }
 
-
 type Seat struct {
-	ID           int          `json:"id"`
+	Id           *uuid.UUID   `json:"id"`
 	Row          int          `json:"row"`
 	Column       int          `json:"column"`
 	SeatCategory SeatCategory `json:"seatCategory"`
+	CinemaHallId *uuid.UUID   `json:"cinemaHallId"`
 }
 
 type SeatCategory string

--- a/src/models/schemas/Event.go
+++ b/src/models/schemas/Event.go
@@ -1,18 +1,24 @@
 package schemas
 
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
 type Event struct {
-	Title   string    `json:"title"`
-	Start   string    `json:"start"` //TODO: fix datatype
-	End     string    `json:"end"`   //TODO: fix datatype
-	Tickets *[]Ticket `json:"tickets"`
+	Id           *uuid.UUID `json:"id"`
+	Title        string     `json:"title"`
+	EventType    EventType  `json:"eventType"`
+	Start        time.Time  `json:"start"`
+	End          time.Time  `json:"end"`
+	Price        int        `json:"price"` // requires conversion
+	CinemaHallId *uuid.UUID `json:"cinemaHallId"`
 }
 
-type SpecialEvent struct {
-	Event
-	Movies *[]Movie `json:"movies"`
-}
+type EventType string
 
-type Showing struct {
-	Event
-	Movie Movie `json:"movie"`
-}
+const (
+	Showing      EventType = "Showing"
+	SpecialEvent EventType = "SpecialEvent"
+)

--- a/src/models/schemas/Movie.go
+++ b/src/models/schemas/Movie.go
@@ -1,21 +1,17 @@
 package schemas
 
+import "github.com/google/uuid"
+
 type Movie struct {
-	Title       string      `json:"title"`
-	Description string      `json:"description"`
-	ReleaseDate string      `json:"releaseDate"`
-	TimeInMin   int         `json:"timeInMin"`
-	FSK         FSK         `json:"fsk"`
-	Producers   *[]Producer `json:"producers"`
-	Actors      *[]Actor    `json:"actors"`
+	Id          *uuid.UUID `json:"id"`
+	Title       string     `json:"title"`
+	Description string     `json:"description"`
+	ReleaseDate string     `json:"releaseDate"`
+	TimeInMin   int        `json:"timeInMin"`
+	FskId       *uuid.UUID `json:"fskId"`
 }
 
-type FSK string
-
-const (
-	Zero     FSK = "FSK ab 0 freigegeben"
-	Six      FSK = "FSK ab 6 freigegeben"
-	Twelve   FSK = "FSK ab 12 freigegeben"
-	Sixteen  FSK = "FSK ab 16 freigegeben"
-	Eighteen FSK = "FSK ab 18 freigegeben"
-)
+type FSK struct {
+	Id  *uuid.UUID `json:"id"`
+	Age int        `json:"age"`
+}

--- a/src/models/schemas/Order.go
+++ b/src/models/schemas/Order.go
@@ -1,23 +1,16 @@
 package schemas
 
+import (
+	//"time"
+
+	"github.com/google/uuid"
+)
+
 type Order struct {
-	ID           int           `json:"id"`
-	Total        int           `json:"total"`
-	Timestamp    string        `json:"timestamp"` //TODO: find better datatype
-	Confirmation *Confirmation `json:"confirmation"`
-}
-
-type Confirmation struct {
-	Order
-	Payment *Payment `json:"payment"`
-}
-
-type Reservation struct {
-	Order
-	// TODO: Payment maybe without reservation?
-}
-
-type Cart struct {
-	LastEdit string    `json:"lastEdit"`
-	Tickets  *[]Ticket `json:"tickets"`
+	Id              *uuid.UUID `json:"id"`
+	Total           int        `json:"total"` // requires conversion
+	TicketId        *uuid.UUID `json:"ticketId"`
+	PaymentMethodId *uuid.UUID `json:"paymentMethodId"`
+	Reservation     bool       `json:"reservation"` // orderType would be better
+	Booking         bool       `json:"booking"`
 }

--- a/src/models/schemas/Payment.go
+++ b/src/models/schemas/Payment.go
@@ -1,34 +1,8 @@
 package schemas
 
-type Payment struct {
-	PaymentMethod *PaymentMethod `json:"paymentMethod"`
-	Invoice       Invoice        `json:"Invoice"`
-}
+import "github.com/google/uuid"
 
 type PaymentMethod struct {
-	// TODO: information
-}
-
-type Mastercard struct {
-	PaymentMethod
-}
-
-type PayPal struct {
-	PaymentMethod
-}
-
-type ApplePay struct {
-	PaymentMethod
-}
-
-type Visa struct {
-	PaymentMethod
-}
-
-type Cash struct {
-	PaymentMethod
-}
-
-type Invoice struct {
-	// TODO:
+	Id     *uuid.UUID `json:"id"`
+	Method string     `json:"method"`
 }

--- a/src/models/schemas/PresentationSchedule.go
+++ b/src/models/schemas/PresentationSchedule.go
@@ -1,5 +1,0 @@
-package schemas
-
-type PresentationSchedule struct {
-	Events *[]Event `json:"events"`
-}

--- a/src/models/schemas/ProducerAndActor.go
+++ b/src/models/schemas/ProducerAndActor.go
@@ -1,9 +1,15 @@
 package schemas
 
+import "github.com/google/uuid"
+
 type Producer struct {
-	// TODO
+	Id   *uuid.UUID `json:"id"`
+	Name string     `json:"name"`
+	Age  int        `json:"age"`
 }
 
 type Actor struct {
-	// TODO
+	Id   *uuid.UUID `json:"id"`
+	Name string     `json:"name"`
+	Age  int        `json:"age"`
 }

--- a/src/models/schemas/Theatre.go
+++ b/src/models/schemas/Theatre.go
@@ -1,9 +1,9 @@
 package schemas
 
+import "github.com/google/uuid"
+
 type Theatre struct {
-	ID                   int                   `json:"id"`
-	Name                 string                `json:"name"`
-	Address              Address               `json:"address"`
-	Theatres             []CinemaHall          `json:"theatres"`
-	PresentationSchedule *PresentationSchedule `json:"presentationSchedule"`
+	Id        *uuid.UUID `json:"id"`
+	Name      string     `json:"name"`
+	AddressId *uuid.UUID `json:"addressId"`
 }

--- a/src/models/schemas/Ticket.go
+++ b/src/models/schemas/Ticket.go
@@ -1,16 +1,20 @@
 package schemas
 
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
 type Ticket struct {
-	ID            int           `json:"id"`
-	Price         float64       `json:"price"`
-	Timestamp     string        `json:"timestamp"` //TODO: find better datatype
-	Validated     bool          `json:"validated"`
-	Paid          bool          `json:"paid"`
-	Reserved      bool          `json:"reserved"`
-	Seat          *Seat         `json:"seat"`
-	QrCode        string        `json:"qrCode"` // TODO: make maybe as Object, depending on how this works
-	PriceCategory PriceCategory `json:"priceCategory"`
-	Order         *Order        `json:"order"`
+	Id        *uuid.UUID `json:"id"`
+	Timestamp time.Time  `json:"timestamp"`
+	Validated bool       `json:"validated"`
+	Paid      bool       `json:"paid"`
+	Reserved  bool       `json:"reserved"`
+	Price     int        `json:"price"` // requires conversion
+	SeatId    *uuid.UUID `json:"seatId"`
+	PriceCategory PriceCategory `json:"priceCategory"` // should have own table
 }
 
 type PriceCategory string

--- a/src/models/schemas/User.go
+++ b/src/models/schemas/User.go
@@ -1,31 +1,20 @@
 package schemas
 
+import "github.com/google/uuid"
+
 type User struct {
-	ID        int     `json:"id"`
-	FirstName string  `json:"firstName"`
-	LastName  string  `json:"LastName"`
-	Email     string  `json:"email"`
-	Password  string  `json:"password"` // TODO: hash or what?
-	Address   Address `json:"address"`
+	Id        *uuid.UUID `json:"id"`
+	FirstName string     `json:"firstName"`
+	LastName  string     `json:"lastName"`
+	Email     string     `json:"email"`
+	Age       int        `json:"age"`
+	Password  string     `json:"password"` // TODO: hash or what?
+	AddressId *uuid.UUID `json:"addressId"`
 }
 
-type Customer struct {
-	WatchedMovies   *[]Movie `json:"watchedMovies"`
-	SuggestedMovies *[]Movie `json:"suggestedMovies"`
-	SavedMovies     *[]Movie `json:"savedMovies"`
-	Orders          *[]Order `json:"orders"`
-	Cart            *[]Cart  `json:"card"`
-	User
-}
-
-type Employee struct {
-	Customer
-}
-
-type Admin struct {
-	Employee
-}
-
-type Cashier struct {
-	Employee
+type UserMovies struct {
+	Id       *uuid.UUID `json:"id"` // probably not needed
+	UserId   *uuid.UUID `json:"userId"`
+	MovieId  *uuid.UUID `json:"movieId"`
+	ListType string     `json:"listType"`
 }


### PR DESCRIPTION
Use uuids for the id fields.
Schema structs should have the same schema as the tables. Therefore, also the foreign keys should be uuids.
Furthermore, aggregations have been removed from the structs as they do not appear in the schemas. They should be created by executing queries.