### PR TITLE
speedy

### DIFF
--- a/create_mocks
+++ b/create_mocks
@@ -23,5 +23,7 @@
 ~/go/bin/mockgen -source=./src/repositories/price_category_repository.go -destination=./src/mocks/price_category_repository_mock.go -package=mocks
 ~/go/bin/mockgen -source=./src/repositories/ticket_repository.go -destination=./src/mocks/ticket_repository_mock.go -package=mocks
 ~/go/bin/mockgen -source=./src/repositories/eventseat_repository.go -destination=./src/mocks/eventseat_repository_mock.go -package=mocks
+~/go/bin/mockgen -source=./src/repositories/event_repository.go -destination=./src/mocks/event_repository_mock.go -package=mocks
+~/go/bin/mockgen -source=./src/repositories/order_repository.go -destination=./src/mocks/order_repository_mock.go -package=mocks
 ~/go/bin/mockgen -source=./src/repositories/review_repository.go -destination=./src/mocks/review_repository_mock.go -package=mocks
 ~/go/bin/mockgen -source=./src/repositories/user_movies_repository.go -destination=./src/mocks/user_movies_repository_mock.go -package=mocks

--- a/create_sql_jet.go
+++ b/create_sql_jet.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/go-jet/jet/v2/generator/metadata"
 	"github.com/go-jet/jet/v2/generator/template"
-	"github.com/google/uuid"
 
 	mysql2 "github.com/go-jet/jet/v2/generator/mysql"
 	mysql3 "github.com/go-jet/jet/v2/mysql"
@@ -51,9 +51,12 @@ func GenerateJetMySQL(dbMySQLConnection mysql2.DBConnection) {
 									defaultTableModelField := template.DefaultTableModelField(columnMetaData)
 
 									switch defaultTableModelField.Type.Name {
-									case "[]byte", "*[]byte":
-										defaultTableModelField.Type = template.NewType(&uuid.UUID{})
+									case "[]byte":
+										defaultTableModelField.Type = template.NewType(myid.UUID{})
+									case "*[]byte":
+										defaultTableModelField.Type = template.NewType(&myid.UUID{})
 									}
+									
 									if columnMetaData.Name == "password" {
 										defaultTableModelField = defaultTableModelField.UseTags("json:\"-\"")
 									}

--- a/src/controllers/actor_controller.go
+++ b/src/controllers/actor_controller.go
@@ -4,21 +4,21 @@ import (
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/repositories"
-	"github.com/google/uuid"
 )
 
 type ActorControllerI interface {
-	GetActorById(actorId *uuid.UUID) (*models.ActorDTO, *models.KTSError)
+	GetActorById(actorId *myid.UUID) (*models.ActorDTO, *models.KTSError)
 	GetActors() (*[]models.GetActorsDTO, *models.KTSError)
-	CreateActor(actor *models.CreateActorDTO) (*uuid.UUID, *models.KTSError)
+	CreateActor(actor *models.CreateActorDTO) (*myid.UUID, *models.KTSError)
 }
 
 type ActorController struct {
 	ActorRepo repositories.ActorRepoI
 }
 
-func (ac *ActorController) GetActorById(actorId *uuid.UUID) (*models.ActorDTO, *models.KTSError) {
+func (ac *ActorController) GetActorById(actorId *myid.UUID) (*models.ActorDTO, *models.KTSError) {
 	return ac.ActorRepo.GetActorById(actorId)
 }
 
@@ -26,7 +26,7 @@ func (ac *ActorController) GetActors() (*[]models.GetActorsDTO, *models.KTSError
 	return ac.ActorRepo.GetActors()
 }
 
-func (ac *ActorController) CreateActor(actorDto *models.CreateActorDTO) (*uuid.UUID, *models.KTSError) {
+func (ac *ActorController) CreateActor(actorDto *models.CreateActorDTO) (*myid.UUID, *models.KTSError) {
 	if actorDto == nil {
 		return nil, kts_errors.KTS_BAD_REQUEST
 	}
@@ -43,7 +43,7 @@ func (ac *ActorController) CreateActor(actorDto *models.CreateActorDTO) (*uuid.U
 
 	for _, imageUrl := range imageUrls {
 		_, kts_err := ac.ActorRepo.CreateActorPicture(&model.ActorPictures{
-			ActorID: actorId,
+			ActorID: *actorId,
 			PicURL:  &imageUrl,
 		})
 

--- a/src/controllers/actor_controller_test.go
+++ b/src/controllers/actor_controller_test.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -11,16 +10,16 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/mocks"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 func TestGetActorByID(t *testing.T) {
 
-	id := utils.NewUUID()
+	id := myid.NewUUID()
 
 	testCases := []struct {
 		name             string
-		actorId          *uuid.UUID
+		actorId          *myid.UUID
 		expectedActorDTO *models.ActorDTO
 		expectedError    *models.KTSError
 	}{
@@ -29,7 +28,7 @@ func TestGetActorByID(t *testing.T) {
 			actorId: id,
 			expectedActorDTO: &models.ActorDTO{
 				Actors: model.Actors{
-					ID:          id,
+					ID:          *id,
 					Name:        "Test Actor",
 					Description: "Test Description",
 				},
@@ -81,7 +80,7 @@ func TestGetActors(t *testing.T) {
 			expectedActorsDTO: &[]models.GetActorsDTO{
 				{
 					Actors: model.Actors{
-						ID:          utils.NewUUID(),
+						ID:          *myid.NewUUID(),
 						Name:        "Test Actor",
 						Description: "Test Description",
 					},
@@ -122,19 +121,19 @@ func TestGetActors(t *testing.T) {
 
 func TestCreateActor(t *testing.T) {
 
-	id := utils.NewUUID()
+	id := myid.NewUUID()
 
 	testCases := []struct {
 		name          string
 		actorDto      *models.CreateActorDTO
-		expectedActor *uuid.UUID
+		expectedActor *myid.UUID
 		expectedError *models.KTSError
 	}{
 		{
 			name: "Create actor",
 			actorDto: &models.CreateActorDTO{
 				Actors: model.Actors{
-					ID:          id,
+					ID:          *id,
 					Name:        "Test Actor",
 					Description: "Test Description",
 				},

--- a/src/controllers/event_controller_test.go
+++ b/src/controllers/event_controller_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/mocks"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/samples"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
 	"go.uber.org/mock/gomock"
 )
 
@@ -24,14 +24,14 @@ func TestEventController_CreateEvent(t *testing.T) {
 			End:          time.Now().Add(time.Hour),
 			Description:  nil,
 			EventType:    "Test event type",
-			CinemaHallID: utils.NewUUID(),
+			CinemaHallID: *myid.NewUUID(),
 		},
-		Movies: []*uuid.UUID{
-			utils.NewUUID(),
+		Movies: []*myid.UUID{
+			myid.NewUUID(),
 		},
 		EventSeatCategories: []model.EventSeatCategories{
 			{
-				SeatCategoryID: utils.NewUUID(),
+				SeatCategoryID: *myid.NewUUID(),
 				Price:          100,
 			},
 		},
@@ -41,18 +41,18 @@ func TestEventController_CreateEvent(t *testing.T) {
 		name            string
 		expectFuncs     func(mockEventRepo *mocks.MockEventRepo, mockTheatreRepo *mocks.MockTheaterRepoI, t *testing.T)
 		expectedError   *models.KTSError
-		expectedEventId *uuid.UUID
+		expectedEventId *myid.UUID
 		eventRequest    *models.CreateEvtDTO
 	}{
 		{
 			name: "Create Event",
 			expectFuncs: func(mockEventRepo *mocks.MockEventRepo, mockTheatreRepo *mocks.MockTheaterRepoI, t *testing.T) {
-				mockEventRepo.EXPECT().CreateEvent(&eventRequest.Events).Return(eventRequest.Events.ID, nil)
-				mockEventRepo.EXPECT().AddEventMovie(eventRequest.Events.ID, eventRequest.Movies[0]).Return(nil)
+				mockEventRepo.EXPECT().CreateEvent(&eventRequest.Events).Return(&eventRequest.Events.ID, nil)
+				mockEventRepo.EXPECT().AddEventMovie(&eventRequest.Events.ID, eventRequest.Movies[0]).Return(nil)
 				mockEventRepo.EXPECT().CreateEventSeatCategory(&eventRequest.EventSeatCategories[0]).Return(nil)
-				mockTheatreRepo.EXPECT().GetSeatsForCinemaHall(eventRequest.Events.CinemaHallID).Return([]model.Seats{
+				mockTheatreRepo.EXPECT().GetSeatsForCinemaHall(&eventRequest.Events.CinemaHallID).Return([]model.Seats{
 					{
-						ID:             utils.NewUUID(),
+						ID:             *myid.NewUUID(),
 						RowNr:          1,
 						ColumnNr:       1,
 						CinemaHallID:   eventRequest.Events.CinemaHallID,
@@ -62,7 +62,7 @@ func TestEventController_CreateEvent(t *testing.T) {
 				mockEventRepo.EXPECT().CreateEventSeat(gomock.Any()).Return(nil)
 			},
 			expectedError:   nil,
-			expectedEventId: eventRequest.Events.ID,
+			expectedEventId: &eventRequest.Events.ID,
 			eventRequest:    eventRequest,
 		},
 		{
@@ -77,8 +77,8 @@ func TestEventController_CreateEvent(t *testing.T) {
 		{
 			name: "Add Event Movie returns error",
 			expectFuncs: func(mockEventRepo *mocks.MockEventRepo, mockTheatreRepo *mocks.MockTheaterRepoI, t *testing.T) {
-				mockEventRepo.EXPECT().CreateEvent(&eventRequest.Events).Return(eventRequest.Events.ID, nil)
-				mockEventRepo.EXPECT().AddEventMovie(eventRequest.Events.ID, eventRequest.Movies[0]).Return(kts_errors.KTS_INTERNAL_ERROR)
+				mockEventRepo.EXPECT().CreateEvent(&eventRequest.Events).Return(&eventRequest.Events.ID, nil)
+				mockEventRepo.EXPECT().AddEventMovie(&eventRequest.Events.ID, eventRequest.Movies[0]).Return(kts_errors.KTS_INTERNAL_ERROR)
 			},
 			expectedError:   kts_errors.KTS_INTERNAL_ERROR,
 			expectedEventId: nil,
@@ -87,8 +87,8 @@ func TestEventController_CreateEvent(t *testing.T) {
 		{
 			name: "Create Event Seat Category returns error",
 			expectFuncs: func(mockEventRepo *mocks.MockEventRepo, mockTheatreRepo *mocks.MockTheaterRepoI, t *testing.T) {
-				mockEventRepo.EXPECT().CreateEvent(&eventRequest.Events).Return(eventRequest.Events.ID, nil)
-				mockEventRepo.EXPECT().AddEventMovie(eventRequest.Events.ID, eventRequest.Movies[0]).Return(nil)
+				mockEventRepo.EXPECT().CreateEvent(&eventRequest.Events).Return(&eventRequest.Events.ID, nil)
+				mockEventRepo.EXPECT().AddEventMovie(&eventRequest.Events.ID, eventRequest.Movies[0]).Return(nil)
 				mockEventRepo.EXPECT().CreateEventSeatCategory(&eventRequest.EventSeatCategories[0]).Return(kts_errors.KTS_INTERNAL_ERROR)
 			},
 			expectedError:   kts_errors.KTS_INTERNAL_ERROR,
@@ -98,10 +98,10 @@ func TestEventController_CreateEvent(t *testing.T) {
 		{
 			name: "Get Seats For Cinema Hall returns error",
 			expectFuncs: func(mockEventRepo *mocks.MockEventRepo, mockTheatreRepo *mocks.MockTheaterRepoI, t *testing.T) {
-				mockEventRepo.EXPECT().CreateEvent(&eventRequest.Events).Return(eventRequest.Events.ID, nil)
-				mockEventRepo.EXPECT().AddEventMovie(eventRequest.Events.ID, eventRequest.Movies[0]).Return(nil)
+				mockEventRepo.EXPECT().CreateEvent(&eventRequest.Events).Return(&eventRequest.Events.ID, nil)
+				mockEventRepo.EXPECT().AddEventMovie(&eventRequest.Events.ID, eventRequest.Movies[0]).Return(nil)
 				mockEventRepo.EXPECT().CreateEventSeatCategory(&eventRequest.EventSeatCategories[0]).Return(nil)
-				mockTheatreRepo.EXPECT().GetSeatsForCinemaHall(eventRequest.Events.CinemaHallID).Return(nil, kts_errors.KTS_INTERNAL_ERROR)
+				mockTheatreRepo.EXPECT().GetSeatsForCinemaHall(&eventRequest.Events.CinemaHallID).Return(nil, kts_errors.KTS_INTERNAL_ERROR)
 			},
 			expectedError:   kts_errors.KTS_INTERNAL_ERROR,
 			expectedEventId: nil,
@@ -110,12 +110,12 @@ func TestEventController_CreateEvent(t *testing.T) {
 		{
 			name: "Create Event Seat returns error",
 			expectFuncs: func(mockEventRepo *mocks.MockEventRepo, mockTheatreRepo *mocks.MockTheaterRepoI, t *testing.T) {
-				mockEventRepo.EXPECT().CreateEvent(&eventRequest.Events).Return(eventRequest.Events.ID, nil)
-				mockEventRepo.EXPECT().AddEventMovie(eventRequest.Events.ID, eventRequest.Movies[0]).Return(nil)
+				mockEventRepo.EXPECT().CreateEvent(&eventRequest.Events).Return(&eventRequest.Events.ID, nil)
+				mockEventRepo.EXPECT().AddEventMovie(&eventRequest.Events.ID, eventRequest.Movies[0]).Return(nil)
 				mockEventRepo.EXPECT().CreateEventSeatCategory(&eventRequest.EventSeatCategories[0]).Return(nil)
-				mockTheatreRepo.EXPECT().GetSeatsForCinemaHall(eventRequest.Events.CinemaHallID).Return([]model.Seats{
+				mockTheatreRepo.EXPECT().GetSeatsForCinemaHall(&eventRequest.Events.CinemaHallID).Return([]model.Seats{
 					{
-						ID:             utils.NewUUID(),
+						ID:             *myid.NewUUID(),
 						RowNr:          1,
 						ColumnNr:       1,
 						CinemaHallID:   eventRequest.Events.CinemaHallID,
@@ -139,7 +139,7 @@ func TestEventController_CreateEvent(t *testing.T) {
 		{
 			name: "Movies nil or empty",
 			expectFuncs: func(mockEventRepo *mocks.MockEventRepo, mockTheatreRepo *mocks.MockTheaterRepoI, t *testing.T) {
-				mockEventRepo.EXPECT().CreateEvent(&eventRequest.Events).Return(eventRequest.Events.ID, nil)
+				mockEventRepo.EXPECT().CreateEvent(&eventRequest.Events).Return(&eventRequest.Events.ID, nil)
 			},
 			expectedError:   kts_errors.KTS_BAD_REQUEST,
 			expectedEventId: nil,
@@ -150,8 +150,8 @@ func TestEventController_CreateEvent(t *testing.T) {
 		{
 			name: "EventSeatCategories nil or empty",
 			expectFuncs: func(mockEventRepo *mocks.MockEventRepo, mockTheatreRepo *mocks.MockTheaterRepoI, t *testing.T) {
-				mockEventRepo.EXPECT().CreateEvent(&eventRequest.Events).Return(eventRequest.Events.ID, nil)
-				mockEventRepo.EXPECT().AddEventMovie(eventRequest.Events.ID, eventRequest.Movies[0]).Return(nil)
+				mockEventRepo.EXPECT().CreateEvent(&eventRequest.Events).Return(&eventRequest.Events.ID, nil)
+				mockEventRepo.EXPECT().AddEventMovie(&eventRequest.Events.ID, eventRequest.Movies[0]).Return(nil)
 			},
 			expectedError:   kts_errors.KTS_BAD_REQUEST,
 			expectedEventId: nil,
@@ -194,8 +194,8 @@ func TestEventController_CreateEvent(t *testing.T) {
 }
 
 func TestEventController_GetEventsForMovie(t *testing.T) {
-	movieId := utils.NewUUID()
-	theatreId := utils.NewUUID()
+	movieId := myid.NewUUID()
+	theatreId := myid.NewUUID()
 
 	expectedEvents := samples.GetModelEvents()
 
@@ -306,11 +306,11 @@ func TestEventController_GetSpecialEvents(t *testing.T) {
 	}
 }
 func TestEventController_GetEventById(t *testing.T) {
-	eventId := utils.NewUUID()
+	eventId := myid.NewUUID()
 
 	expectedEvent := &models.GetSpecialEventsDTO{
 		Events: model.Events{
-			ID:          eventId,
+			ID:          *eventId,
 			Title:       "Test Event",
 			Description: utils.GetStringPointer("Test Description"),
 		},
@@ -318,7 +318,7 @@ func TestEventController_GetEventById(t *testing.T) {
 
 	tests := []struct {
 		name             string
-		eventId          *uuid.UUID
+		eventId          *myid.UUID
 		expectedEventDTO *models.GetSpecialEventsDTO
 		expectedError    *models.KTSError
 	}{

--- a/src/controllers/eventseats_controller.go
+++ b/src/controllers/eventseats_controller.go
@@ -1,30 +1,31 @@
 package controllers
 
 import (
+	"fmt"
 	"slices"
 	"time"
 
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/repositories"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
 )
 
 type EventSeatControllerI interface {
-	GetEventSeats(eventId *uuid.UUID, userId *uuid.UUID) (*[][]models.GetSeatsForSeatSelectorDTO, *[]models.GetSeatsForSeatSelectorDTO, *time.Time, *models.KTSError)
-	BlockEventSeat(eventId *uuid.UUID, eventSeatId *uuid.UUID, userId *uuid.UUID) (*time.Time, *models.KTSError)
-	AreUserSeatsNextToEachOther(eventId *uuid.UUID, userId *uuid.UUID, eventSeatId *uuid.UUID) (bool, *models.KTSError)
-	UnblockEventSeat(eventId *uuid.UUID, eventSeatId *uuid.UUID, userId *uuid.UUID) (*time.Time, *models.KTSError)
-	UnblockAllEventSeats(eventId *uuid.UUID, userId *uuid.UUID) *models.KTSError
-	GetSelectedSeats(eventId *uuid.UUID, userId *uuid.UUID) (*[]models.GetSlectedSeatsDTO, *models.KTSError)
+	GetEventSeats(eventId *myid.UUID, userId *myid.UUID) (*[][]models.GetSeatsForSeatSelectorDTO, *[]models.GetSeatsForSeatSelectorDTO, *time.Time, *models.KTSError)
+	BlockEventSeat(eventId *myid.UUID, eventSeatId *myid.UUID, userId *myid.UUID) (*time.Time, *models.KTSError)
+	AreUserSeatsNextToEachOther(eventId *myid.UUID, userId *myid.UUID, eventSeatId *myid.UUID) (bool, *models.KTSError)
+	UnblockEventSeat(eventId *myid.UUID, eventSeatId *myid.UUID, userId *myid.UUID) (*time.Time, *models.KTSError)
+	UnblockAllEventSeats(eventId *myid.UUID, userId *myid.UUID) *models.KTSError
+	GetSelectedSeats(eventId *myid.UUID, userId *myid.UUID) (*[]models.GetSlectedSeatsDTO, *models.KTSError)
 }
 
 type EventSeatController struct {
 	EventSeatRepo repositories.EventSeatRepoI
 }
 
-func (esc *EventSeatController) GetEventSeats(eventId *uuid.UUID, userId *uuid.UUID) (*[][]models.GetSeatsForSeatSelectorDTO, *[]models.GetSeatsForSeatSelectorDTO, *time.Time, *models.KTSError) {
+func (esc *EventSeatController) GetEventSeats(eventId *myid.UUID, userId *myid.UUID) (*[][]models.GetSeatsForSeatSelectorDTO, *[]models.GetSeatsForSeatSelectorDTO, *time.Time, *models.KTSError) {
 	seats, kts_err := esc.EventSeatRepo.GetEventSeats(eventId)
 
 	if kts_err != nil {
@@ -34,10 +35,13 @@ func (esc *EventSeatController) GetEventSeats(eventId *uuid.UUID, userId *uuid.U
 	seatRows := make(map[int32][]models.GetSeatsForSeatSelectorDTO)
 	currentUserSeats := []models.GetSeatsForSeatSelectorDTO{}
 	var blockedUntil *time.Time
+	fmt.Printf("ps: %p %v\n", &((*seats)[0].EventSeat.ID), ((*seats)[0].EventSeat.ID))
+	fmt.Printf("ps: %p %v\n", &((*seats)[1].EventSeat.ID), ((*seats)[1].EventSeat.ID))
+	fmt.Printf("ps: %p %v\n", &((*seats)[2].EventSeat.ID), ((*seats)[2].EventSeat.ID))
 
 	for _, seat := range *seats {
 		currentSeat := models.GetSeatsForSeatSelectorDTO{
-			ID:             seat.EventSeat.ID,
+			// ID:             &seat.EventSeat.ID,
 			RowNr:          seat.Seat.RowNr,
 			ColumnNr:       seat.Seat.ColumnNr,
 			Available:      (seat.EventSeat.BlockedUntil == nil || seat.EventSeat.BlockedUntil.Before(time.Now()) || seat.EventSeat.UserID == nil) && !seat.EventSeat.Booked,
@@ -46,6 +50,8 @@ func (esc *EventSeatController) GetEventSeats(eventId *uuid.UUID, userId *uuid.U
 			Type:           seat.Seat.Type,
 			Price:          seat.EventSeatCategory.Price,
 		}
+		currentSeat.ID = &(seat.EventSeat.ID)
+		fmt.Printf("s: %p\n", &seat.EventSeat.ID)
 
 		if seat.EventSeat.UserID != nil && *seat.EventSeat.UserID == *userId && !seat.EventSeat.Booked && seat.EventSeat.BlockedUntil != nil && seat.EventSeat.BlockedUntil.After(time.Now()) {
 			currentUserSeats = append(currentUserSeats, currentSeat)
@@ -56,12 +62,15 @@ func (esc *EventSeatController) GetEventSeats(eventId *uuid.UUID, userId *uuid.U
 
 		seatRow := seatRows[currentSeat.RowNr]
 		seatRows[currentSeat.RowNr] = append(seatRow, currentSeat)
+		for i := range seatRows[0] {
+			fmt.Printf("%d: %p\n", i, seatRows[0][i].ID)
+		}
 	}
 
 	return seatMapToSlice(seatRows), &currentUserSeats, blockedUntil, nil
 }
 
-func (esc *EventSeatController) BlockEventSeat(eventId *uuid.UUID, eventSeatId *uuid.UUID, userId *uuid.UUID) (*time.Time, *models.KTSError) {
+func (esc *EventSeatController) BlockEventSeat(eventId *myid.UUID, eventSeatId *myid.UUID, userId *myid.UUID) (*time.Time, *models.KTSError) {
 	currentTime := time.Now()
 	blockedUntil := currentTime.Add(utils.BLOCKED_TICKET_TIME)
 
@@ -86,7 +95,7 @@ func (esc *EventSeatController) BlockEventSeat(eventId *uuid.UUID, eventSeatId *
 	return &blockedUntil, nil
 }
 
-func (esc *EventSeatController) UnblockEventSeat(eventId *uuid.UUID, eventSeatId *uuid.UUID, userId *uuid.UUID) (*time.Time, *models.KTSError) {
+func (esc *EventSeatController) UnblockEventSeat(eventId *myid.UUID, eventSeatId *myid.UUID, userId *myid.UUID) (*time.Time, *models.KTSError) {
 	currentTime := time.Now()
 	blockedUntil := currentTime.Add(utils.BLOCKED_TICKET_TIME)
 
@@ -114,11 +123,11 @@ func (esc *EventSeatController) UnblockEventSeat(eventId *uuid.UUID, eventSeatId
 	return &blockedUntil, nil
 }
 
-func (esc *EventSeatController) UnblockAllEventSeats(eventId *uuid.UUID, userId *uuid.UUID) *models.KTSError {
+func (esc *EventSeatController) UnblockAllEventSeats(eventId *myid.UUID, userId *myid.UUID) *models.KTSError {
 	return esc.EventSeatRepo.UnblockAllEventSeats(eventId, userId)
 }
 
-func (esc *EventSeatController) AreUserSeatsNextToEachOtherWithoutSeat(eventId *uuid.UUID, userId *uuid.UUID, eventSeatId *uuid.UUID) (bool, *models.KTSError) {
+func (esc *EventSeatController) AreUserSeatsNextToEachOtherWithoutSeat(eventId *myid.UUID, userId *myid.UUID, eventSeatId *myid.UUID) (bool, *models.KTSError) {
 	seats, err := esc.EventSeatRepo.GetEventSeats(eventId)
 
 	if err != nil {
@@ -130,7 +139,7 @@ func (esc *EventSeatController) AreUserSeatsNextToEachOtherWithoutSeat(eventId *
 	var emtpySeatArray []models.GetEventSeatsDTO
 
 	for _, seat := range *seats {
-		if ((seat.EventSeat.UserID != nil && *seat.EventSeat.UserID == *userId) && (seat.EventSeat.BlockedUntil != nil && seat.EventSeat.BlockedUntil.After(time.Now())) && !seat.EventSeat.Booked) && *seat.EventSeat.ID != *eventSeatId {
+		if ((seat.EventSeat.UserID != nil && *seat.EventSeat.UserID == *userId) && (seat.EventSeat.BlockedUntil != nil && seat.EventSeat.BlockedUntil.After(time.Now())) && !seat.EventSeat.Booked) && seat.EventSeat.ID != *eventSeatId {
 			if rowNr == -1 {
 				rowNr = seat.Seat.RowNr
 			} else if rowNr != seat.Seat.RowNr {
@@ -173,7 +182,7 @@ func (esc *EventSeatController) AreUserSeatsNextToEachOtherWithoutSeat(eventId *
 	return true, nil
 }
 
-func (esc *EventSeatController) AreUserSeatsNextToEachOther(eventId *uuid.UUID, userId *uuid.UUID, eventSeatId *uuid.UUID) (bool, *models.KTSError) {
+func (esc *EventSeatController) AreUserSeatsNextToEachOther(eventId *myid.UUID, userId *myid.UUID, eventSeatId *myid.UUID) (bool, *models.KTSError) {
 	seats, err := esc.EventSeatRepo.GetEventSeats(eventId)
 
 	if err != nil {
@@ -185,7 +194,7 @@ func (esc *EventSeatController) AreUserSeatsNextToEachOther(eventId *uuid.UUID, 
 	var emtpySeatArray []models.GetEventSeatsDTO
 
 	for _, seat := range *seats {
-		if (((seat.EventSeat.UserID != nil && *seat.EventSeat.UserID == *userId) && (seat.EventSeat.BlockedUntil != nil && seat.EventSeat.BlockedUntil.After(time.Now()))) && !seat.EventSeat.Booked) || *seat.EventSeat.ID == *eventSeatId {
+		if (((seat.EventSeat.UserID != nil && *seat.EventSeat.UserID == *userId) && (seat.EventSeat.BlockedUntil != nil && seat.EventSeat.BlockedUntil.After(time.Now()))) && !seat.EventSeat.Booked) || seat.EventSeat.ID == *eventSeatId {
 			if rowNr == -1 {
 				rowNr = seat.Seat.RowNr
 			} else if rowNr != seat.Seat.RowNr {
@@ -228,7 +237,7 @@ func (esc *EventSeatController) AreUserSeatsNextToEachOther(eventId *uuid.UUID, 
 	return true, nil
 }
 
-func (esc *EventSeatController) GetSelectedSeats(eventId *uuid.UUID, userId *uuid.UUID) (*[]models.GetSlectedSeatsDTO, *models.KTSError) {
+func (esc *EventSeatController) GetSelectedSeats(eventId *myid.UUID, userId *myid.UUID) (*[]models.GetSlectedSeatsDTO, *models.KTSError) {
 	return esc.EventSeatRepo.GetSelectedSeats(eventId, userId)
 }
 

--- a/src/controllers/eventseats_controller_test.go
+++ b/src/controllers/eventseats_controller_test.go
@@ -9,98 +9,98 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/mocks"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
 	"go.uber.org/mock/gomock"
 )
 
 func TestEventSeatController_GetEventSeats(t *testing.T) {
-	eventId := utils.NewUUID()
-	userId := utils.NewUUID()
+	eventId := myid.New()
+	userId := myid.New()
 
 	blockedUntil := time.Now().Add(time.Minute * 5)
 
 	eventSeats := []models.GetEventSeatsDTO{
 		{
 			EventSeat: model.EventSeats{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				Booked:       false,
 				BlockedUntil: nil,
 				UserID:       nil,
 				EventID:      eventId,
-				SeatID:       utils.NewUUID(),
+				SeatID:       myid.New(),
 			},
 			Seat: model.Seats{
-				ID:             utils.NewUUID(),
+				ID:             myid.New(),
 				RowNr:          0,
 				ColumnNr:       0,
-				SeatCategoryID: utils.NewUUID(),
+				SeatCategoryID: myid.New(),
 			},
 			SeatCategory: model.SeatCategories{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				CategoryName: "standard",
 			},
 			EventSeatCategory: model.EventSeatCategories{
 				Price:          100,
 				EventID:        eventId,
-				SeatCategoryID: utils.NewUUID(),
+				SeatCategoryID: myid.New(),
 			},
 		},
 		{
 			EventSeat: model.EventSeats{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				Booked:       false,
 				BlockedUntil: nil,
 				UserID:       nil,
 				EventID:      eventId,
-				SeatID:       utils.NewUUID(),
+				SeatID:       myid.New(),
 			},
 			Seat: model.Seats{
-				ID:             utils.NewUUID(),
+				ID:             myid.New(),
 				RowNr:          0,
 				ColumnNr:       1,
-				SeatCategoryID: utils.NewUUID(),
+				SeatCategoryID: myid.New(),
 			},
 			SeatCategory: model.SeatCategories{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				CategoryName: "standard",
 			},
 			EventSeatCategory: model.EventSeatCategories{
 				Price:          100,
 				EventID:        eventId,
-				SeatCategoryID: utils.NewUUID(),
+				SeatCategoryID: myid.New(),
 			},
 		},
 		{
 			EventSeat: model.EventSeats{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				Booked:       false,
 				BlockedUntil: &blockedUntil,
-				UserID:       userId,
+				UserID:       &userId,
 				EventID:      eventId,
-				SeatID:       utils.NewUUID(),
+				SeatID:       myid.New(),
 			},
 			Seat: model.Seats{
-				ID:             utils.NewUUID(),
+				ID:             myid.New(),
 				RowNr:          1,
 				ColumnNr:       0,
-				SeatCategoryID: utils.NewUUID(),
+				SeatCategoryID: myid.New(),
 			},
 			SeatCategory: model.SeatCategories{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				CategoryName: "standard",
 			},
 			EventSeatCategory: model.EventSeatCategories{
 				Price:          100,
 				EventID:        eventId,
-				SeatCategoryID: utils.NewUUID(),
+				SeatCategoryID: myid.New(),
 			},
 		},
 	}
 
 	seatsSlice := []models.GetSeatsForSeatSelectorDTO{
 		{
-			ID:             eventSeats[0].EventSeat.ID,
+			ID:             &eventSeats[0].EventSeat.ID,
 			RowNr:          eventSeats[0].Seat.RowNr,
 			ColumnNr:       eventSeats[0].Seat.ColumnNr,
 			Available:      true,
@@ -109,7 +109,7 @@ func TestEventSeatController_GetEventSeats(t *testing.T) {
 			Price:          eventSeats[0].EventSeatCategory.Price,
 		},
 		{
-			ID:             eventSeats[1].EventSeat.ID,
+			ID:             &eventSeats[1].EventSeat.ID,
 			RowNr:          eventSeats[1].Seat.RowNr,
 			ColumnNr:       eventSeats[1].Seat.ColumnNr,
 			Available:      true,
@@ -118,7 +118,7 @@ func TestEventSeatController_GetEventSeats(t *testing.T) {
 			Price:          eventSeats[1].EventSeatCategory.Price,
 		},
 		{
-			ID:             eventSeats[2].EventSeat.ID,
+			ID:             &eventSeats[2].EventSeat.ID,
 			RowNr:          eventSeats[2].Seat.RowNr,
 			ColumnNr:       eventSeats[2].Seat.ColumnNr,
 			Available:      false,
@@ -153,7 +153,7 @@ func TestEventSeatController_GetEventSeats(t *testing.T) {
 		{
 			name: "Get event seats",
 			expectFuncs: func(mockEventSeatRepo *mocks.MockEventSeatRepoI, t *testing.T) {
-				mockEventSeatRepo.EXPECT().GetEventSeats(eventId).Return(&eventSeats, nil)
+				mockEventSeatRepo.EXPECT().GetEventSeats(&eventId).Return(&eventSeats, nil)
 			},
 			expectedError:            nil,
 			expectedSeatRows:         &expectedSeatRows,
@@ -163,7 +163,7 @@ func TestEventSeatController_GetEventSeats(t *testing.T) {
 		{
 			name: "Get event seats - error",
 			expectFuncs: func(mockEventSeatRepo *mocks.MockEventSeatRepoI, t *testing.T) {
-				mockEventSeatRepo.EXPECT().GetEventSeats(eventId).Return(nil, kts_errors.KTS_INTERNAL_ERROR)
+				mockEventSeatRepo.EXPECT().GetEventSeats(&eventId).Return(nil, kts_errors.KTS_INTERNAL_ERROR)
 
 			},
 			expectedError:            kts_errors.KTS_INTERNAL_ERROR,
@@ -189,11 +189,11 @@ func TestEventSeatController_GetEventSeats(t *testing.T) {
 
 			// When
 
-			seatMap, currentUserSeats, timeBlock, err := eventSeatController.GetEventSeats(eventId, userId)
+			seatMap, currentUserSeats, timeBlock, err := eventSeatController.GetEventSeats(&eventId, &userId)
 
 			// Then
 			if !reflect.DeepEqual(seatMap, tt.expectedSeatRows) {
-				t.Errorf("Expected seat map: %v, but got: %v", expectedSeatRows, seatMap)
+				t.Errorf("Expected seat map: %v, but got: %v", tt.expectedSeatRows, seatMap)
 			}
 
 			if !reflect.DeepEqual(currentUserSeats, tt.expectedCurrentUserSeats) {
@@ -213,9 +213,9 @@ func TestEventSeatController_GetEventSeats(t *testing.T) {
 }
 
 func TestEventSeatController_BlockEventSeat(t *testing.T) {
-	eventId := utils.NewUUID()
-	eventSeatId := utils.NewUUID()
-	userId := utils.NewUUID()
+	eventId := myid.NewUUID()
+	eventSeatId := myid.NewUUID()
+	userId := myid.NewUUID()
 
 	tests := []struct {
 		name          string
@@ -292,9 +292,9 @@ func TestEventSeatController_BlockEventSeat(t *testing.T) {
 }
 func TestEventSeatController_AreUserSeatsNextToEachOther(t *testing.T) {
 
-	eventSeatId := utils.NewUUID()
-	eventId := utils.NewUUID()
-	userId := utils.NewUUID()
+	eventSeatId := myid.NewUUID()
+	eventId := myid.NewUUID()
+	userId := myid.NewUUID()
 
 	test := []struct {
 		name           string
@@ -382,140 +382,140 @@ func TestEventSeatController_AreUserSeatsNextToEachOther(t *testing.T) {
 	}
 }
 
-func GetEventSeatsDTO(eventId *uuid.UUID, userId *uuid.UUID, eventSeatId *uuid.UUID) []models.GetEventSeatsDTO {
+func GetEventSeatsDTO(eventId *myid.UUID, userId *myid.UUID, eventSeatId *myid.UUID) []models.GetEventSeatsDTO {
 	blockedUntil := time.Now().Add(time.Minute * 5)
 	return []models.GetEventSeatsDTO{
 		{
 			EventSeat: model.EventSeats{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				Booked:       false,
 				BlockedUntil: nil,
 				UserID:       nil,
-				EventID:      eventId,
-				SeatID:       utils.NewUUID(),
+				EventID:      *eventId,
+				SeatID:       myid.New(),
 			},
 			Seat: model.Seats{
-				ID:             utils.NewUUID(),
+				ID:             myid.New(),
 				RowNr:          1,
 				ColumnNr:       1,
-				SeatCategoryID: utils.NewUUID(),
+				SeatCategoryID: myid.New(),
 			},
 			SeatCategory: model.SeatCategories{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				CategoryName: "standard",
 			},
 			EventSeatCategory: model.EventSeatCategories{
 				Price:          100,
-				EventID:        eventId,
-				SeatCategoryID: utils.NewUUID(),
+				EventID:        *eventId,
+				SeatCategoryID: myid.New(),
 			},
 		},
 		{
 			EventSeat: model.EventSeats{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				Booked:       false,
 				BlockedUntil: nil,
 				UserID:       nil,
-				EventID:      eventId,
-				SeatID:       utils.NewUUID(),
+				EventID:      *eventId,
+				SeatID:       myid.New(),
 			},
 			Seat: model.Seats{
-				ID:             utils.NewUUID(),
+				ID:             myid.New(),
 				RowNr:          1,
 				ColumnNr:       2,
-				SeatCategoryID: utils.NewUUID(),
+				SeatCategoryID: myid.New(),
 			},
 			SeatCategory: model.SeatCategories{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				CategoryName: "standard",
 			},
 			EventSeatCategory: model.EventSeatCategories{
 				Price:          100,
-				EventID:        eventId,
-				SeatCategoryID: utils.NewUUID(),
+				EventID:        *eventId,
+				SeatCategoryID: myid.New(),
 			},
 		},
 		{
 			EventSeat: model.EventSeats{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				Booked:       false,
 				BlockedUntil: &blockedUntil,
 				UserID:       userId,
-				EventID:      eventId,
-				SeatID:       utils.NewUUID(),
+				EventID:      *eventId,
+				SeatID:       myid.New(),
 			},
 			Seat: model.Seats{
-				ID:             utils.NewUUID(),
+				ID:             myid.New(),
 				RowNr:          2,
 				ColumnNr:       1,
-				SeatCategoryID: utils.NewUUID(),
+				SeatCategoryID: myid.New(),
 			},
 			SeatCategory: model.SeatCategories{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				CategoryName: "standard",
 			},
 			EventSeatCategory: model.EventSeatCategories{
 				Price:          100,
-				EventID:        eventId,
-				SeatCategoryID: utils.NewUUID(),
+				EventID:        *eventId,
+				SeatCategoryID: myid.New(),
 			},
 		},
 		{
 			EventSeat: model.EventSeats{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				Booked:       false,
 				BlockedUntil: &blockedUntil,
 				UserID:       userId,
-				EventID:      eventId,
-				SeatID:       utils.NewUUID(),
+				EventID:      *eventId,
+				SeatID:       myid.New(),
 			},
 			Seat: model.Seats{
-				ID:             utils.NewUUID(),
+				ID:             myid.New(),
 				RowNr:          2,
 				ColumnNr:       2,
-				SeatCategoryID: utils.NewUUID(),
+				SeatCategoryID: myid.New(),
 			},
 			SeatCategory: model.SeatCategories{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				CategoryName: "standard",
 			},
 			EventSeatCategory: model.EventSeatCategories{
 				Price:          100,
-				EventID:        eventId,
-				SeatCategoryID: utils.NewUUID(),
+				EventID:        *eventId,
+				SeatCategoryID: myid.New(),
 			},
 		},
 		{
 			EventSeat: model.EventSeats{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				Booked:       false,
 				BlockedUntil: &blockedUntil,
 				UserID:       userId,
-				EventID:      eventId,
-				SeatID:       utils.NewUUID(),
+				EventID:      *eventId,
+				SeatID:       myid.New(),
 			},
 			Seat: model.Seats{
-				ID:             utils.NewUUID(),
+				ID:             myid.New(),
 				RowNr:          2,
 				ColumnNr:       3,
-				SeatCategoryID: utils.NewUUID(),
+				SeatCategoryID: myid.New(),
 			},
 			SeatCategory: model.SeatCategories{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				CategoryName: "standard",
 			},
 			EventSeatCategory: model.EventSeatCategories{
 				Price:          100,
-				EventID:        eventId,
-				SeatCategoryID: utils.NewUUID(),
+				EventID:        *eventId,
+				SeatCategoryID: myid.New(),
 			},
 		},
 	}
 }
 func TestEventSeatController_AreUserSeatsNextToEachOtherWithoutSeat(t *testing.T) {
-	eventId := utils.NewUUID()
-	userId := utils.NewUUID()
-	eventSeatId := utils.NewUUID()
+	eventId := myid.NewUUID()
+	userId := myid.NewUUID()
+	eventSeatId := myid.NewUUID()
 
 	blockedUntil := time.Now().Add(time.Minute * 5)
 
@@ -532,7 +532,7 @@ func TestEventSeatController_AreUserSeatsNextToEachOtherWithoutSeat(t *testing.T
 				eventSeats := []models.GetEventSeatsDTO{
 					{
 						EventSeat: model.EventSeats{
-							ID:           eventSeatId,
+							ID:           *eventSeatId,
 							UserID:       userId,
 							Booked:       false,
 							BlockedUntil: &blockedUntil,
@@ -544,7 +544,7 @@ func TestEventSeatController_AreUserSeatsNextToEachOtherWithoutSeat(t *testing.T
 					},
 					{
 						EventSeat: model.EventSeats{
-							ID:           utils.NewUUID(),
+							ID:           myid.New(),
 							UserID:       userId,
 							Booked:       false,
 							BlockedUntil: &blockedUntil,
@@ -556,7 +556,7 @@ func TestEventSeatController_AreUserSeatsNextToEachOtherWithoutSeat(t *testing.T
 					},
 					{
 						EventSeat: model.EventSeats{
-							ID:           utils.NewUUID(),
+							ID:           myid.New(),
 							UserID:       userId,
 							Booked:       false,
 							BlockedUntil: &blockedUntil,
@@ -579,7 +579,7 @@ func TestEventSeatController_AreUserSeatsNextToEachOtherWithoutSeat(t *testing.T
 				eventSeats := []models.GetEventSeatsDTO{
 					{
 						EventSeat: model.EventSeats{
-							ID:           utils.NewUUID(),
+							ID:           myid.New(),
 							UserID:       userId,
 							Booked:       false,
 							BlockedUntil: &blockedUntil,
@@ -591,7 +591,7 @@ func TestEventSeatController_AreUserSeatsNextToEachOtherWithoutSeat(t *testing.T
 					},
 					{
 						EventSeat: model.EventSeats{
-							ID:           eventSeatId,
+							ID:           *eventSeatId,
 							UserID:       userId,
 							Booked:       false,
 							BlockedUntil: &blockedUntil,
@@ -603,7 +603,7 @@ func TestEventSeatController_AreUserSeatsNextToEachOtherWithoutSeat(t *testing.T
 					},
 					{
 						EventSeat: model.EventSeats{
-							ID:           utils.NewUUID(),
+							ID:           myid.New(),
 							UserID:       userId,
 							Booked:       false,
 							BlockedUntil: &blockedUntil,
@@ -643,7 +643,7 @@ func TestEventSeatController_AreUserSeatsNextToEachOtherWithoutSeat(t *testing.T
 				eventSeats := []models.GetEventSeatsDTO{
 					{
 						EventSeat: model.EventSeats{
-							ID:           utils.NewUUID(),
+							ID:           myid.New(),
 							UserID:       userId,
 							Booked:       false,
 							BlockedUntil: &blockedUntil,
@@ -655,7 +655,7 @@ func TestEventSeatController_AreUserSeatsNextToEachOtherWithoutSeat(t *testing.T
 					},
 					{
 						EventSeat: model.EventSeats{
-							ID:           eventSeatId,
+							ID:           *eventSeatId,
 							UserID:       userId,
 							Booked:       false,
 							BlockedUntil: &blockedUntil,
@@ -667,7 +667,7 @@ func TestEventSeatController_AreUserSeatsNextToEachOtherWithoutSeat(t *testing.T
 					},
 					{
 						EventSeat: model.EventSeats{
-							ID:           utils.NewUUID(),
+							ID:           myid.New(),
 							UserID:       userId,
 							Booked:       false,
 							BlockedUntil: &blockedUntil,
@@ -690,7 +690,7 @@ func TestEventSeatController_AreUserSeatsNextToEachOtherWithoutSeat(t *testing.T
 				eventSeats := []models.GetEventSeatsDTO{
 					{
 						EventSeat: model.EventSeats{
-							ID:           utils.NewUUID(),
+							ID:           myid.New(),
 							UserID:       userId,
 							Booked:       false,
 							BlockedUntil: &blockedUntil,
@@ -702,7 +702,7 @@ func TestEventSeatController_AreUserSeatsNextToEachOtherWithoutSeat(t *testing.T
 					},
 					{
 						EventSeat: model.EventSeats{
-							ID:           eventSeatId,
+							ID:           *eventSeatId,
 							UserID:       userId,
 							Booked:       false,
 							BlockedUntil: &blockedUntil,
@@ -715,7 +715,7 @@ func TestEventSeatController_AreUserSeatsNextToEachOtherWithoutSeat(t *testing.T
 					},
 					{
 						EventSeat: model.EventSeats{
-							ID:           utils.NewUUID(),
+							ID:           myid.New(),
 							UserID:       userId,
 							Booked:       false,
 							BlockedUntil: &blockedUntil,
@@ -738,7 +738,7 @@ func TestEventSeatController_AreUserSeatsNextToEachOtherWithoutSeat(t *testing.T
 				eventSeats := []models.GetEventSeatsDTO{
 					{
 						EventSeat: model.EventSeats{
-							ID:           eventSeatId,
+							ID:           *eventSeatId,
 							UserID:       userId,
 							Booked:       false,
 							BlockedUntil: &blockedUntil,
@@ -786,9 +786,9 @@ func TestEventSeatController_AreUserSeatsNextToEachOtherWithoutSeat(t *testing.T
 	}
 }
 func TestEventSeatController_UnblockEventSeat(t *testing.T) {
-	eventId := utils.NewUUID()
-	eventSeatId := utils.NewUUID()
-	userId := utils.NewUUID()
+	eventId := myid.NewUUID()
+	eventSeatId := myid.NewUUID()
+	userId := myid.NewUUID()
 
 	tests := []struct {
 		name          string
@@ -805,7 +805,7 @@ func TestEventSeatController_UnblockEventSeat(t *testing.T) {
 				mockEventSeatRepo.EXPECT().GetEventSeats(eventId).Return(&[]models.GetEventSeatsDTO{
 					{
 						EventSeat: model.EventSeats{
-							ID:           eventSeatId,
+							ID:           *eventSeatId,
 							UserID:       userId,
 							Booked:       false,
 							BlockedUntil: &blockedUntil,
@@ -831,7 +831,7 @@ func TestEventSeatController_UnblockEventSeat(t *testing.T) {
 				mockEventSeatRepo.EXPECT().GetEventSeats(eventId).Return(&[]models.GetEventSeatsDTO{
 					{
 						EventSeat: model.EventSeats{
-							ID:           eventSeatId,
+							ID:           *eventSeatId,
 							UserID:       userId,
 							Booked:       false,
 							BlockedUntil: &blockedUntil,
@@ -856,7 +856,7 @@ func TestEventSeatController_UnblockEventSeat(t *testing.T) {
 				mockEventSeatRepo.EXPECT().GetEventSeats(eventId).Return(&[]models.GetEventSeatsDTO{
 					{
 						EventSeat: model.EventSeats{
-							ID:           utils.NewUUID(),
+							ID:           myid.New(),
 							UserID:       userId,
 							Booked:       false,
 							BlockedUntil: &blockedUntil,
@@ -868,7 +868,7 @@ func TestEventSeatController_UnblockEventSeat(t *testing.T) {
 					},
 					{
 						EventSeat: model.EventSeats{
-							ID:           eventSeatId,
+							ID:           *eventSeatId,
 							UserID:       userId,
 							Booked:       false,
 							BlockedUntil: &blockedUntil,
@@ -880,7 +880,7 @@ func TestEventSeatController_UnblockEventSeat(t *testing.T) {
 					},
 					{
 						EventSeat: model.EventSeats{
-							ID:           utils.NewUUID(),
+							ID:           myid.New(),
 							UserID:       userId,
 							Booked:       false,
 							BlockedUntil: &blockedUntil,

--- a/src/controllers/genre_controller.go
+++ b/src/controllers/genre_controller.go
@@ -4,16 +4,16 @@ import (
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/repositories"
-	"github.com/google/uuid"
 )
 
 type GenreControllerI interface {
 	GetGenres() (*[]model.Genres, *models.KTSError)
 	GetGenreByName(name *string) (*model.Genres, *models.KTSError)
-	CreateGenre(name *string) (*uuid.UUID, *models.KTSError)
+	CreateGenre(name *string) (*myid.UUID, *models.KTSError)
 	UpdateGenre(genre *model.Genres) *models.KTSError
-	DeleteGenre(genre_id *uuid.UUID) *models.KTSError
+	DeleteGenre(genre_id *myid.UUID) *models.KTSError
 
 	// All Movies with all Genres - Grouped by Genre
 	GetGenresWithMovies() (*[]models.GenreWithMovies, *models.KTSError)
@@ -40,7 +40,7 @@ func (mc *GenreController) GetGenreByName(name *string) (*model.Genres, *models.
 	return genre, nil
 }
 
-func (mc *GenreController) CreateGenre(name *string) (*uuid.UUID, *models.KTSError) {
+func (mc *GenreController) CreateGenre(name *string) (*myid.UUID, *models.KTSError) {
 	if name == nil {
 		return nil, kts_errors.KTS_BAD_REQUEST
 	}
@@ -60,7 +60,7 @@ func (mc *GenreController) UpdateGenre(genre *model.Genres) *models.KTSError {
 	return nil
 }
 
-func (mc *GenreController) DeleteGenre(genre_id *uuid.UUID) *models.KTSError {
+func (mc *GenreController) DeleteGenre(genre_id *myid.UUID) *models.KTSError {
 	kts_errors := mc.MovieGenreRepo.RemoveAllMovieCombinationWithGenre(genre_id)
 	if kts_errors != nil {
 		return kts_errors

--- a/src/controllers/genre_controller_test.go
+++ b/src/controllers/genre_controller_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/mocks"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/samples"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
@@ -215,7 +215,7 @@ func TestCreateGenre(t *testing.T) {
 			name:      "Create genre",
 			genreName: &sampleGenre.GenreName,
 			setExpectations: func(mockRepo mocks.MockGenreRepositoryI, genreName *string) {
-				mockRepo.EXPECT().CreateGenre(genreName).Return(sampleGenre.ID, nil)
+				mockRepo.EXPECT().CreateGenre(genreName).Return(&sampleGenre.ID, nil)
 			},
 			expectedGenreId: true,
 			expectedError:   nil,
@@ -324,23 +324,23 @@ func TestUpdateGenre(t *testing.T) {
 func TestDeleteGenre(t *testing.T) {
 	sampleGenre := samples.GetSampleGenre()
 
-	genreID := sampleGenre.ID
+	genreID := &sampleGenre.ID
 
 	testCases := []struct {
 		name            string
-		setExpectations func(mockGenreRepo mocks.MockGenreRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, genreID *uuid.UUID)
+		setExpectations func(mockGenreRepo mocks.MockGenreRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, genreID *myid.UUID)
 		expectedError   *models.KTSError
 	}{
 		{
 			name: "MovieGenre deletion failed",
-			setExpectations: func(mockGenreRepo mocks.MockGenreRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, genreID *uuid.UUID) {
+			setExpectations: func(mockGenreRepo mocks.MockGenreRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, genreID *myid.UUID) {
 				mockMovieGenreRepo.EXPECT().RemoveAllMovieCombinationWithGenre(genreID).Return(kts_errors.KTS_INTERNAL_ERROR)
 			},
 			expectedError: kts_errors.KTS_INTERNAL_ERROR,
 		},
 		{
 			name: "Empty result",
-			setExpectations: func(mockGenreRepo mocks.MockGenreRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, genreID *uuid.UUID) {
+			setExpectations: func(mockGenreRepo mocks.MockGenreRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, genreID *myid.UUID) {
 				mockMovieGenreRepo.EXPECT().RemoveAllMovieCombinationWithGenre(genreID).Return(nil)
 				mockGenreRepo.EXPECT().DeleteGenre(genreID).Return(kts_errors.KTS_NOT_FOUND)
 			},
@@ -348,7 +348,7 @@ func TestDeleteGenre(t *testing.T) {
 		},
 		{
 			name: "Delete genre",
-			setExpectations: func(mockGenreRepo mocks.MockGenreRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, genreID *uuid.UUID) {
+			setExpectations: func(mockGenreRepo mocks.MockGenreRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, genreID *myid.UUID) {
 				mockMovieGenreRepo.EXPECT().RemoveAllMovieCombinationWithGenre(genreID).Return(nil)
 				mockGenreRepo.EXPECT().DeleteGenre(genreID).Return(nil)
 			},
@@ -356,7 +356,7 @@ func TestDeleteGenre(t *testing.T) {
 		},
 		{
 			name: "Error while deleting genre",
-			setExpectations: func(mockGenreRepo mocks.MockGenreRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, genreID *uuid.UUID) {
+			setExpectations: func(mockGenreRepo mocks.MockGenreRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, genreID *myid.UUID) {
 				mockMovieGenreRepo.EXPECT().RemoveAllMovieCombinationWithGenre(genreID).Return(nil)
 				mockGenreRepo.EXPECT().DeleteGenre(genreID).Return(kts_errors.KTS_INTERNAL_ERROR)
 			},

--- a/src/controllers/movie_controller.go
+++ b/src/controllers/movie_controller.go
@@ -6,22 +6,22 @@ import (
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/repositories"
-	"github.com/google/uuid"
 )
 
 type MovieControllerI interface {
 	// Movie
 	GetMovies() (*[]model.Movies, *models.KTSError)
-	GetMovieById(movieId *uuid.UUID) (*models.MovieWithEverything, *models.KTSError)
+	GetMovieById(movieId *myid.UUID) (*models.MovieWithEverything, *models.KTSError)
 	GetMovieByName(name *string) (*model.Movies, *models.KTSError)
-	CreateMovie(movie *models.MovieDTOCreate) (*uuid.UUID, *models.KTSError)
+	CreateMovie(movie *models.MovieDTOCreate) (*myid.UUID, *models.KTSError)
 	UpdateMovie(movie *model.Movies) *models.KTSError
-	DeleteMovie(movieId *uuid.UUID) *models.KTSError
+	DeleteMovie(movieId *myid.UUID) *models.KTSError
 
 	// Combine Movie and Genre
-	// AddMovieGenre(movieId *uuid.UUID, genreId *uuid.UUID) *models.KTSError
-	// RemoveMovieGenre(movieId *uuid.UUID, genreId *uuid.UUID) *models.KTSError
+	// AddMovieGenre(movieId *myid.UUID, genreId *myid.UUID) *models.KTSError
+	// RemoveMovieGenre(movieId *myid.UUID, genreId *myid.UUID) *models.KTSError
 
 	// All Movies with all Genres - Grouped by Movie
 	GetMoviesWithGenres() (*[]models.MovieWithGenres, *models.KTSError)
@@ -53,7 +53,7 @@ func (mc *MovieController) GetMovieByName(name *string) (*model.Movies, *models.
 	return movie, nil
 }
 
-func (mc *MovieController) CreateMovie(movie *models.MovieDTOCreate) (*uuid.UUID, *models.KTSError) {
+func (mc *MovieController) CreateMovie(movie *models.MovieDTOCreate) (*myid.UUID, *models.KTSError) {
 	if movie.Movies == (model.Movies{}) {
 		log.Print("Movie is nil")
 		return nil, kts_errors.KTS_BAD_REQUEST
@@ -108,7 +108,7 @@ func (mc *MovieController) UpdateMovie(movie *model.Movies) *models.KTSError {
 	return mc.MovieRepo.UpdateMovie(movie)
 }
 
-func (mc *MovieController) DeleteMovie(movieId *uuid.UUID) *models.KTSError {
+func (mc *MovieController) DeleteMovie(movieId *myid.UUID) *models.KTSError {
 	// MovieGenre
 	kts_errors := mc.MovieGenreRepo.RemoveAllGenreCombinationWithMovie(movieId)
 	if kts_errors != nil {
@@ -157,7 +157,7 @@ func (mc *MovieController) GetMoviesWithGenres() (*[]models.MovieWithGenres, *mo
 	return movies, nil
 }
 
-func (mc *MovieController) GetMovieById(movieId *uuid.UUID) (*models.MovieWithEverything, *models.KTSError) {
+func (mc *MovieController) GetMovieById(movieId *myid.UUID) (*models.MovieWithEverything, *models.KTSError) {
 	movie, kts_errors := mc.MovieRepo.GetMovieById(movieId)
 	if kts_errors != nil {
 		return nil, kts_errors

--- a/src/controllers/movie_controller_test.go
+++ b/src/controllers/movie_controller_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/mocks"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/samples"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
@@ -202,17 +202,17 @@ func TestGetMoviesWithGenres(t *testing.T) {
 func TestGetMovieById(t *testing.T) {
 	sampleMovie := samples.GetSampleMovieByIdWithEverything()
 
-	id := sampleMovie.ID
+	id := &sampleMovie.ID
 
 	testCases := []struct {
 		name            string
-		setExpectations func(mockRepo mocks.MockMovieRepositoryI, movieId *uuid.UUID)
+		setExpectations func(mockRepo mocks.MockMovieRepositoryI, movieId *myid.UUID)
 		expectedMovies  *models.MovieWithEverything
 		expectedError   *models.KTSError
 	}{
 		{
 			name: "Empty result",
-			setExpectations: func(mockRepo mocks.MockMovieRepositoryI, movieId *uuid.UUID) {
+			setExpectations: func(mockRepo mocks.MockMovieRepositoryI, movieId *myid.UUID) {
 				mockRepo.EXPECT().GetMovieById(id).Return(nil, kts_errors.KTS_NOT_FOUND)
 			},
 			expectedMovies: nil,
@@ -220,7 +220,7 @@ func TestGetMovieById(t *testing.T) {
 		},
 		{
 			name: "Multiple movies",
-			setExpectations: func(mockRepo mocks.MockMovieRepositoryI, movieId *uuid.UUID) {
+			setExpectations: func(mockRepo mocks.MockMovieRepositoryI, movieId *myid.UUID) {
 				mockRepo.EXPECT().GetMovieById(id).Return(sampleMovie, nil)
 			},
 			expectedMovies: sampleMovie,
@@ -228,7 +228,7 @@ func TestGetMovieById(t *testing.T) {
 		},
 		{
 			name: "Error while querying movies",
-			setExpectations: func(mockRepo mocks.MockMovieRepositoryI, movieId *uuid.UUID) {
+			setExpectations: func(mockRepo mocks.MockMovieRepositoryI, movieId *myid.UUID) {
 				mockRepo.EXPECT().GetMovieById(id).Return(nil, kts_errors.KTS_INTERNAL_ERROR)
 			},
 			expectedMovies: nil,
@@ -301,8 +301,8 @@ func TestCreateMovie(t *testing.T) {
 				GenresID: sampleMovie.GenresID,
 			},
 			setExpectations: func(mockMovieRepo mocks.MockMovieRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, mockMovieActorRepo mocks.MockMovieActorRepositoryI, mockMovieProducerRepo mocks.MockMovieProducerRepositoryI, movie *models.MovieDTOCreate) {
-				mockMovieRepo.EXPECT().CreateMovie(&movie.Movies).Return(sampleMovie.ID, nil)
-				mockMovieGenreRepo.EXPECT().AddMovieGenre(sampleMovie.ID, gomock.Any()).Return(kts_errors.KTS_INTERNAL_ERROR)
+				mockMovieRepo.EXPECT().CreateMovie(&movie.Movies).Return(&sampleMovie.ID, nil)
+				mockMovieGenreRepo.EXPECT().AddMovieGenre(&sampleMovie.ID, gomock.Any()).Return(kts_errors.KTS_INTERNAL_ERROR)
 			},
 			expectedMoviesId: false,
 			expectedError:    kts_errors.KTS_INTERNAL_ERROR,
@@ -316,9 +316,9 @@ func TestCreateMovie(t *testing.T) {
 				ActorsID: sampleMovie.ActorsID,
 			},
 			setExpectations: func(mockMovieRepo mocks.MockMovieRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, mockMovieActorRepo mocks.MockMovieActorRepositoryI, mockMovieProducerRepo mocks.MockMovieProducerRepositoryI, movie *models.MovieDTOCreate) {
-				mockMovieRepo.EXPECT().CreateMovie(&movie.Movies).Return(sampleMovie.ID, nil)
-				mockMovieGenreRepo.EXPECT().AddMovieGenre(sampleMovie.ID, gomock.Any()).Return(nil)
-				mockMovieActorRepo.EXPECT().AddMovieActor(sampleMovie.ID, gomock.Any()).Return(kts_errors.KTS_INTERNAL_ERROR)
+				mockMovieRepo.EXPECT().CreateMovie(&movie.Movies).Return(&sampleMovie.ID, nil)
+				mockMovieGenreRepo.EXPECT().AddMovieGenre(&sampleMovie.ID, gomock.Any()).Return(nil)
+				mockMovieActorRepo.EXPECT().AddMovieActor(&sampleMovie.ID, gomock.Any()).Return(kts_errors.KTS_INTERNAL_ERROR)
 			},
 			expectedMoviesId: false,
 			expectedError:    kts_errors.KTS_INTERNAL_ERROR,
@@ -333,10 +333,10 @@ func TestCreateMovie(t *testing.T) {
 				ProducersID: sampleMovie.ProducersID,
 			},
 			setExpectations: func(mockMovieRepo mocks.MockMovieRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, mockMovieActorRepo mocks.MockMovieActorRepositoryI, mockMovieProducerRepo mocks.MockMovieProducerRepositoryI, movie *models.MovieDTOCreate) {
-				mockMovieRepo.EXPECT().CreateMovie(&movie.Movies).Return(sampleMovie.ID, nil)
-				mockMovieGenreRepo.EXPECT().AddMovieGenre(sampleMovie.ID, gomock.Any()).Return(nil)
-				mockMovieActorRepo.EXPECT().AddMovieActor(sampleMovie.ID, gomock.Any()).Return(nil)
-				mockMovieProducerRepo.EXPECT().AddMovieProducer(sampleMovie.ID, gomock.Any()).Return(kts_errors.KTS_INTERNAL_ERROR)
+				mockMovieRepo.EXPECT().CreateMovie(&movie.Movies).Return(&sampleMovie.ID, nil)
+				mockMovieGenreRepo.EXPECT().AddMovieGenre(&sampleMovie.ID, gomock.Any()).Return(nil)
+				mockMovieActorRepo.EXPECT().AddMovieActor(&sampleMovie.ID, gomock.Any()).Return(nil)
+				mockMovieProducerRepo.EXPECT().AddMovieProducer(&sampleMovie.ID, gomock.Any()).Return(kts_errors.KTS_INTERNAL_ERROR)
 			},
 			expectedMoviesId: false,
 			expectedError:    kts_errors.KTS_INTERNAL_ERROR,
@@ -351,10 +351,10 @@ func TestCreateMovie(t *testing.T) {
 				ProducersID: sampleMovie.ProducersID,
 			},
 			setExpectations: func(mockMovieRepo mocks.MockMovieRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, mockMovieActorRepo mocks.MockMovieActorRepositoryI, mockMovieProducerRepo mocks.MockMovieProducerRepositoryI, movie *models.MovieDTOCreate) {
-				mockMovieRepo.EXPECT().CreateMovie(&movie.Movies).Return(sampleMovie.ID, nil)
-				mockMovieGenreRepo.EXPECT().AddMovieGenre(sampleMovie.ID, gomock.Any()).Return(nil)
-				mockMovieActorRepo.EXPECT().AddMovieActor(sampleMovie.ID, gomock.Any()).Return(nil)
-				mockMovieProducerRepo.EXPECT().AddMovieProducer(sampleMovie.ID, gomock.Any()).Return(nil)
+				mockMovieRepo.EXPECT().CreateMovie(&movie.Movies).Return(&sampleMovie.ID, nil)
+				mockMovieGenreRepo.EXPECT().AddMovieGenre(&sampleMovie.ID, gomock.Any()).Return(nil)
+				mockMovieActorRepo.EXPECT().AddMovieActor(&sampleMovie.ID, gomock.Any()).Return(nil)
+				mockMovieProducerRepo.EXPECT().AddMovieProducer(&sampleMovie.ID, gomock.Any()).Return(nil)
 			},
 			expectedMoviesId: true,
 			expectedError:    nil,
@@ -462,12 +462,12 @@ func TestDeleteMovie(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		setExpectations func(mockMovieRepo mocks.MockMovieRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, mockMovieActorRepo mocks.MockMovieActorRepositoryI, mockMovieProducerRepo mocks.MockMovieProducerRepositoryI, mockReviewRepo mocks.MockReviewRepositoryI, mockUserMovieRepo mocks.MockUserMovieRepositoryI, movieId *uuid.UUID)
+		setExpectations func(mockMovieRepo mocks.MockMovieRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, mockMovieActorRepo mocks.MockMovieActorRepositoryI, mockMovieProducerRepo mocks.MockMovieProducerRepositoryI, mockReviewRepo mocks.MockReviewRepositoryI, mockUserMovieRepo mocks.MockUserMovieRepositoryI, movieId *myid.UUID)
 		expectedError   *models.KTSError
 	}{
 		{
 			name: "Delete movie",
-			setExpectations: func(mockMovieRepo mocks.MockMovieRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, mockMovieActorRepo mocks.MockMovieActorRepositoryI, mockMovieProducerRepo mocks.MockMovieProducerRepositoryI, mockReviewRepo mocks.MockReviewRepositoryI, mockUserMovieRepo mocks.MockUserMovieRepositoryI, movieId *uuid.UUID) {
+			setExpectations: func(mockMovieRepo mocks.MockMovieRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, mockMovieActorRepo mocks.MockMovieActorRepositoryI, mockMovieProducerRepo mocks.MockMovieProducerRepositoryI, mockReviewRepo mocks.MockReviewRepositoryI, mockUserMovieRepo mocks.MockUserMovieRepositoryI, movieId *myid.UUID) {
 				mockMovieGenreRepo.EXPECT().RemoveAllGenreCombinationWithMovie(movieId).Return(nil)
 				mockMovieActorRepo.EXPECT().RemoveAllActorCombinationWithMovie(movieId).Return(nil)
 				mockMovieProducerRepo.EXPECT().RemoveAllProducerCombinationWithMovie(movieId).Return(nil)
@@ -479,7 +479,7 @@ func TestDeleteMovie(t *testing.T) {
 		},
 		{
 			name: "Error while deleting MovieProducer",
-			setExpectations: func(mockMovieRepo mocks.MockMovieRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, mockMovieActorRepo mocks.MockMovieActorRepositoryI, mockMovieProducerRepo mocks.MockMovieProducerRepositoryI, mockReviewRepo mocks.MockReviewRepositoryI, mockUserMovieRepo mocks.MockUserMovieRepositoryI, movieId *uuid.UUID) {
+			setExpectations: func(mockMovieRepo mocks.MockMovieRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, mockMovieActorRepo mocks.MockMovieActorRepositoryI, mockMovieProducerRepo mocks.MockMovieProducerRepositoryI, mockReviewRepo mocks.MockReviewRepositoryI, mockUserMovieRepo mocks.MockUserMovieRepositoryI, movieId *myid.UUID) {
 				mockMovieGenreRepo.EXPECT().RemoveAllGenreCombinationWithMovie(movieId).Return(nil)
 				mockMovieActorRepo.EXPECT().RemoveAllActorCombinationWithMovie(movieId).Return(nil)
 				mockMovieProducerRepo.EXPECT().RemoveAllProducerCombinationWithMovie(movieId).Return(kts_errors.KTS_INTERNAL_ERROR)
@@ -488,7 +488,7 @@ func TestDeleteMovie(t *testing.T) {
 		},
 		{
 			name: "Error while deleting MovieActor",
-			setExpectations: func(mockMovieRepo mocks.MockMovieRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, mockMovieActorRepo mocks.MockMovieActorRepositoryI, mockMovieProducerRepo mocks.MockMovieProducerRepositoryI, mockReviewRepo mocks.MockReviewRepositoryI, mockUserMovieRepo mocks.MockUserMovieRepositoryI, movieId *uuid.UUID) {
+			setExpectations: func(mockMovieRepo mocks.MockMovieRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, mockMovieActorRepo mocks.MockMovieActorRepositoryI, mockMovieProducerRepo mocks.MockMovieProducerRepositoryI, mockReviewRepo mocks.MockReviewRepositoryI, mockUserMovieRepo mocks.MockUserMovieRepositoryI, movieId *myid.UUID) {
 				mockMovieGenreRepo.EXPECT().RemoveAllGenreCombinationWithMovie(movieId).Return(nil)
 				mockMovieActorRepo.EXPECT().RemoveAllActorCombinationWithMovie(movieId).Return(kts_errors.KTS_INTERNAL_ERROR)
 			},
@@ -496,14 +496,14 @@ func TestDeleteMovie(t *testing.T) {
 		},
 		{
 			name: "Error while deleting MovieGenre",
-			setExpectations: func(mockMovieRepo mocks.MockMovieRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, mockMovieActorRepo mocks.MockMovieActorRepositoryI, mockMovieProducerRepo mocks.MockMovieProducerRepositoryI, mockReviewRepo mocks.MockReviewRepositoryI, mockUserMovieRepo mocks.MockUserMovieRepositoryI, movieId *uuid.UUID) {
+			setExpectations: func(mockMovieRepo mocks.MockMovieRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, mockMovieActorRepo mocks.MockMovieActorRepositoryI, mockMovieProducerRepo mocks.MockMovieProducerRepositoryI, mockReviewRepo mocks.MockReviewRepositoryI, mockUserMovieRepo mocks.MockUserMovieRepositoryI, movieId *myid.UUID) {
 				mockMovieGenreRepo.EXPECT().RemoveAllGenreCombinationWithMovie(movieId).Return(kts_errors.KTS_INTERNAL_ERROR)
 			},
 			expectedError: kts_errors.KTS_INTERNAL_ERROR,
 		},
 		{
 			name: "Movie not found",
-			setExpectations: func(mockMovieRepo mocks.MockMovieRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, mockMovieActorRepo mocks.MockMovieActorRepositoryI, mockMovieProducerRepo mocks.MockMovieProducerRepositoryI, mockReviewRepo mocks.MockReviewRepositoryI, mockUserMovieRepo mocks.MockUserMovieRepositoryI, movieId *uuid.UUID) {
+			setExpectations: func(mockMovieRepo mocks.MockMovieRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, mockMovieActorRepo mocks.MockMovieActorRepositoryI, mockMovieProducerRepo mocks.MockMovieProducerRepositoryI, mockReviewRepo mocks.MockReviewRepositoryI, mockUserMovieRepo mocks.MockUserMovieRepositoryI, movieId *myid.UUID) {
 				mockMovieGenreRepo.EXPECT().RemoveAllGenreCombinationWithMovie(movieId).Return(nil)
 				mockMovieActorRepo.EXPECT().RemoveAllActorCombinationWithMovie(movieId).Return(nil)
 				mockMovieProducerRepo.EXPECT().RemoveAllProducerCombinationWithMovie(movieId).Return(nil)
@@ -515,7 +515,7 @@ func TestDeleteMovie(t *testing.T) {
 		},
 		{
 			name: "MovieReview internal error",
-			setExpectations: func(mockMovieRepo mocks.MockMovieRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, mockMovieActorRepo mocks.MockMovieActorRepositoryI, mockMovieProducerRepo mocks.MockMovieProducerRepositoryI, mockReviewRepo mocks.MockReviewRepositoryI, mockUserMovieRepo mocks.MockUserMovieRepositoryI, movieId *uuid.UUID) {
+			setExpectations: func(mockMovieRepo mocks.MockMovieRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, mockMovieActorRepo mocks.MockMovieActorRepositoryI, mockMovieProducerRepo mocks.MockMovieProducerRepositoryI, mockReviewRepo mocks.MockReviewRepositoryI, mockUserMovieRepo mocks.MockUserMovieRepositoryI, movieId *myid.UUID) {
 				mockMovieGenreRepo.EXPECT().RemoveAllGenreCombinationWithMovie(movieId).Return(nil)
 				mockMovieActorRepo.EXPECT().RemoveAllActorCombinationWithMovie(movieId).Return(nil)
 				mockMovieProducerRepo.EXPECT().RemoveAllProducerCombinationWithMovie(movieId).Return(nil)
@@ -525,7 +525,7 @@ func TestDeleteMovie(t *testing.T) {
 		},
 		{
 			name: "UserMovie internal error",
-			setExpectations: func(mockMovieRepo mocks.MockMovieRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, mockMovieActorRepo mocks.MockMovieActorRepositoryI, mockMovieProducerRepo mocks.MockMovieProducerRepositoryI, mockReviewRepo mocks.MockReviewRepositoryI, mockUserMovieRepo mocks.MockUserMovieRepositoryI, movieId *uuid.UUID) {
+			setExpectations: func(mockMovieRepo mocks.MockMovieRepositoryI, mockMovieGenreRepo mocks.MockMovieGenreRepositoryI, mockMovieActorRepo mocks.MockMovieActorRepositoryI, mockMovieProducerRepo mocks.MockMovieProducerRepositoryI, mockReviewRepo mocks.MockReviewRepositoryI, mockUserMovieRepo mocks.MockUserMovieRepositoryI, movieId *myid.UUID) {
 				mockMovieGenreRepo.EXPECT().RemoveAllGenreCombinationWithMovie(movieId).Return(nil)
 				mockMovieActorRepo.EXPECT().RemoveAllActorCombinationWithMovie(movieId).Return(nil)
 				mockMovieProducerRepo.EXPECT().RemoveAllProducerCombinationWithMovie(movieId).Return(nil)
@@ -557,11 +557,11 @@ func TestDeleteMovie(t *testing.T) {
 			}
 
 			// define expectations
-			tc.setExpectations(*movieRepoMock, *genreRepoMock, *actorRepoMock, *producerRepoMock, *reviewRepoMock, *userMovieRepoMock, sampleMovie.ID)
+			tc.setExpectations(*movieRepoMock, *genreRepoMock, *actorRepoMock, *producerRepoMock, *reviewRepoMock, *userMovieRepoMock, &sampleMovie.ID)
 
 			// WHEN
 			// Call the method under test
-			kts_err := movieController.DeleteMovie(sampleMovie.ID)
+			kts_err := movieController.DeleteMovie(&sampleMovie.ID)
 
 			// Verify
 			assert.Equal(t, tc.expectedError, kts_err)

--- a/src/controllers/order_controller_test.go
+++ b/src/controllers/order_controller_test.go
@@ -6,8 +6,8 @@ import (
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/mocks"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/samples"
-	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
@@ -15,7 +15,7 @@ import (
 func TestOrderController_CreateOrder(t *testing.T) {
 	priceCategories := samples.GetPriceCategories()
 	eventSeats := samples.GetGetSlectedSeatsDTO()
-	order := samples.GetOrder(priceCategories, eventSeats, utils.NewUUID())
+	order := samples.GetOrder(priceCategories, eventSeats, myid.NewUUID())
 
 	tests := []struct {
 		name          string
@@ -29,8 +29,8 @@ func TestOrderController_CreateOrder(t *testing.T) {
 			expectedFuncs: func(mockOrderRepo *mocks.MockOrderRepoI, mockEventSeatRepo *mocks.MockEventSeatRepoI, mockPriceCategoryRepo *mocks.MockPriceCategoryRepositoryI, mockTicketRepo *mocks.MockTicketRepositoryI) {
 				mockEventSeatRepo.EXPECT().GetSelectedSeats(gomock.Any(), gomock.Any()).Return(eventSeats, nil)
 				mockPriceCategoryRepo.EXPECT().GetPriceCategories().Return(priceCategories, nil)
-				mockOrderRepo.EXPECT().CreateOrder(gomock.Any()).Return(utils.NewUUID(), nil)
-				mockTicketRepo.EXPECT().CreateTicket(gomock.Any()).Return(utils.NewUUID(), nil).Times(2)
+				mockOrderRepo.EXPECT().CreateOrder(gomock.Any()).Return(myid.NewUUID(), nil)
+				mockTicketRepo.EXPECT().CreateTicket(gomock.Any()).Return(myid.NewUUID(), nil).Times(2)
 				mockEventSeatRepo.EXPECT().UpdateEventSeat(gomock.Any()).Return(nil).Times(2)
 			},
 			expectedErr:   nil,
@@ -72,7 +72,7 @@ func TestOrderController_CreateOrder(t *testing.T) {
 			expectedFuncs: func(mockOrderRepo *mocks.MockOrderRepoI, mockEventSeatRepo *mocks.MockEventSeatRepoI, mockPriceCategoryRepo *mocks.MockPriceCategoryRepositoryI, mockTicketRepo *mocks.MockTicketRepositoryI) {
 				mockEventSeatRepo.EXPECT().GetSelectedSeats(gomock.Any(), gomock.Any()).Return(eventSeats, nil)
 				mockPriceCategoryRepo.EXPECT().GetPriceCategories().Return(priceCategories, nil)
-				mockOrderRepo.EXPECT().CreateOrder(gomock.Any()).Return(utils.NewUUID(), nil)
+				mockOrderRepo.EXPECT().CreateOrder(gomock.Any()).Return(myid.NewUUID(), nil)
 				mockTicketRepo.EXPECT().CreateTicket(gomock.Any()).Return(nil, kts_errors.KTS_NOT_FOUND)
 			},
 			expectedErr:   kts_errors.KTS_NOT_FOUND,
@@ -84,8 +84,8 @@ func TestOrderController_CreateOrder(t *testing.T) {
 			expectedFuncs: func(mockOrderRepo *mocks.MockOrderRepoI, mockEventSeatRepo *mocks.MockEventSeatRepoI, mockPriceCategoryRepo *mocks.MockPriceCategoryRepositoryI, mockTicketRepo *mocks.MockTicketRepositoryI) {
 				mockEventSeatRepo.EXPECT().GetSelectedSeats(gomock.Any(), gomock.Any()).Return(eventSeats, nil)
 				mockPriceCategoryRepo.EXPECT().GetPriceCategories().Return(priceCategories, nil)
-				mockOrderRepo.EXPECT().CreateOrder(gomock.Any()).Return(utils.NewUUID(), nil)
-				mockTicketRepo.EXPECT().CreateTicket(gomock.Any()).Return(utils.NewUUID(), nil).Times(2)
+				mockOrderRepo.EXPECT().CreateOrder(gomock.Any()).Return(myid.NewUUID(), nil)
+				mockTicketRepo.EXPECT().CreateTicket(gomock.Any()).Return(myid.NewUUID(), nil).Times(2)
 				mockEventSeatRepo.EXPECT().UpdateEventSeat(gomock.Any()).Return(kts_errors.KTS_NOT_FOUND)
 			},
 			expectedErr:   kts_errors.KTS_NOT_FOUND,
@@ -121,7 +121,7 @@ func TestOrderController_CreateOrder(t *testing.T) {
 				TicketRepo:        mockTicketRepo,
 			}
 
-			orderId, err := oc.CreateOrder(tc.orderRequest, utils.NewUUID(), utils.NewUUID(), false)
+			orderId, err := oc.CreateOrder(tc.orderRequest, myid.NewUUID(), myid.NewUUID(), false)
 
 			if tc.expectOrderId {
 				assert.NotNil(t, orderId)

--- a/src/controllers/price_category_controller.go
+++ b/src/controllers/price_category_controller.go
@@ -4,23 +4,23 @@ import (
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/repositories"
-	"github.com/google/uuid"
 )
 
 type PriceCategoryControllerI interface {
 	GetPriceCategories() (*[]model.PriceCategories, *models.KTSError)
-	GetPriceCategoryById(id *uuid.UUID) (*model.PriceCategories, *models.KTSError)
-	CreatePriceCategory(priceCategory *model.PriceCategories) (*uuid.UUID, *models.KTSError)
-	UpdatePriceCategory(priceCategory *model.PriceCategories) (*uuid.UUID, *models.KTSError)
-	DeletePriceCategory(id *uuid.UUID) *models.KTSError
+	GetPriceCategoryById(id *myid.UUID) (*model.PriceCategories, *models.KTSError)
+	CreatePriceCategory(priceCategory *model.PriceCategories) (*myid.UUID, *models.KTSError)
+	UpdatePriceCategory(priceCategory *model.PriceCategories) (*myid.UUID, *models.KTSError)
+	DeletePriceCategory(id *myid.UUID) *models.KTSError
 }
 
 type PriceCategoryController struct {
 	PriceCategoryRepository repositories.PriceCategoryRepositoryI
 }
 
-func (pcc *PriceCategoryController) GetPriceCategoryById(priceCategoryID *uuid.UUID) (*model.PriceCategories, *models.KTSError) {
+func (pcc *PriceCategoryController) GetPriceCategoryById(priceCategoryID *myid.UUID) (*model.PriceCategories, *models.KTSError) {
 	return pcc.PriceCategoryRepository.GetPriceCategoryById(priceCategoryID)
 }
 
@@ -28,7 +28,7 @@ func (pcc *PriceCategoryController) GetPriceCategories() (*[]model.PriceCategori
 	return pcc.PriceCategoryRepository.GetPriceCategories()
 }
 
-func (pcc *PriceCategoryController) CreatePriceCategory(priceCategory *model.PriceCategories) (*uuid.UUID, *models.KTSError) {
+func (pcc *PriceCategoryController) CreatePriceCategory(priceCategory *model.PriceCategories) (*myid.UUID, *models.KTSError) {
 	if priceCategory == nil {
 		return nil, kts_errors.KTS_BAD_REQUEST
 	}
@@ -41,7 +41,7 @@ func (pcc *PriceCategoryController) CreatePriceCategory(priceCategory *model.Pri
 	return priceCategoryID, nil
 }
 
-func (pcc *PriceCategoryController) UpdatePriceCategory(priceCategory *model.PriceCategories) (*uuid.UUID, *models.KTSError) {
+func (pcc *PriceCategoryController) UpdatePriceCategory(priceCategory *model.PriceCategories) (*myid.UUID, *models.KTSError) {
 	if priceCategory == nil {
 		return nil, kts_errors.KTS_BAD_REQUEST
 	}
@@ -54,7 +54,7 @@ func (pcc *PriceCategoryController) UpdatePriceCategory(priceCategory *model.Pri
 	return priceCategoryID, nil
 }
 
-func (pcc *PriceCategoryController) DeletePriceCategory(id *uuid.UUID) *models.KTSError {
+func (pcc *PriceCategoryController) DeletePriceCategory(id *myid.UUID) *models.KTSError {
 	if id == nil {
 		return kts_errors.KTS_BAD_REQUEST
 	}

--- a/src/controllers/price_category_controller_test.go
+++ b/src/controllers/price_category_controller_test.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -11,19 +10,19 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/mocks"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 func TestGetProducers(t *testing.T) {
 
 	samplePriceCategories := &[]model.PriceCategories{
 		{
-			ID:           utils.NewUUID(),
+			ID:           myid.New(),
 			CategoryName: "StudentDiscount",
 			Price:        16,
 		},
 		{
-			ID:           utils.NewUUID(),
+			ID:           myid.New(),
 			CategoryName: "ChildDiscount",
 			Price:        16,
 		},
@@ -85,20 +84,20 @@ func TestGetProducers(t *testing.T) {
 
 func TestGetProducerByID(t *testing.T) {
 	samplePriceCategory := &model.PriceCategories{
-		ID:           utils.NewUUID(),
+		ID:           myid.New(),
 		CategoryName: "StudentDiscount",
 		Price:        16,
 	}
 
 	testCases := []struct {
 		name                  string
-		setExpectations       func(mockRepo mocks.MockPriceCategoryRepositoryI, priceCategoryID *uuid.UUID)
+		setExpectations       func(mockRepo mocks.MockPriceCategoryRepositoryI, priceCategoryID *myid.UUID)
 		expectedPriceCategory *model.PriceCategories
 		expectedError         *models.KTSError
 	}{
 		{
 			name: "Empty result",
-			setExpectations: func(mockRepo mocks.MockPriceCategoryRepositoryI, priceCategoryID *uuid.UUID) {
+			setExpectations: func(mockRepo mocks.MockPriceCategoryRepositoryI, priceCategoryID *myid.UUID) {
 				mockRepo.EXPECT().GetPriceCategoryById(priceCategoryID).Return(nil, kts_errors.KTS_NOT_FOUND)
 			},
 			expectedPriceCategory: nil,
@@ -106,7 +105,7 @@ func TestGetProducerByID(t *testing.T) {
 		},
 		{
 			name: "One priceCategory",
-			setExpectations: func(mockRepo mocks.MockPriceCategoryRepositoryI, priceCategoryID *uuid.UUID) {
+			setExpectations: func(mockRepo mocks.MockPriceCategoryRepositoryI, priceCategoryID *myid.UUID) {
 				mockRepo.EXPECT().GetPriceCategoryById(priceCategoryID).Return(samplePriceCategory, nil)
 			},
 			expectedPriceCategory: samplePriceCategory,
@@ -114,7 +113,7 @@ func TestGetProducerByID(t *testing.T) {
 		},
 		{
 			name: "Error while querying for priceCategory",
-			setExpectations: func(mockRepo mocks.MockPriceCategoryRepositoryI, priceCategoryID *uuid.UUID) {
+			setExpectations: func(mockRepo mocks.MockPriceCategoryRepositoryI, priceCategoryID *myid.UUID) {
 				mockRepo.EXPECT().GetPriceCategoryById(priceCategoryID).Return(nil, kts_errors.KTS_INTERNAL_ERROR)
 			},
 			expectedPriceCategory: nil,
@@ -133,10 +132,10 @@ func TestGetProducerByID(t *testing.T) {
 			}
 
 			// define expectations
-			tc.setExpectations(*priceCategoryRepoMock, samplePriceCategory.ID)
+			tc.setExpectations(*priceCategoryRepoMock, &samplePriceCategory.ID)
 
 			// WHEN
-			priceCategory, kts_err := priceCategoryController.GetPriceCategoryById(samplePriceCategory.ID)
+			priceCategory, kts_err := priceCategoryController.GetPriceCategoryById(&samplePriceCategory.ID)
 
 			// THEN
 			assert.Equal(t, tc.expectedPriceCategory, priceCategory)
@@ -148,7 +147,7 @@ func TestGetProducerByID(t *testing.T) {
 func TestCreateProducer(t *testing.T) {
 
 	samplePriceCategory := &model.PriceCategories{
-		ID:           utils.NewUUID(),
+		ID:           myid.New(),
 		CategoryName: "StudentDiscount",
 		Price:        16,
 	}
@@ -173,7 +172,7 @@ func TestCreateProducer(t *testing.T) {
 			name:          "Create priceCategory",
 			priceCategory: samplePriceCategory,
 			setExpectations: func(mockProducerRepo mocks.MockPriceCategoryRepositoryI, priceCategory *model.PriceCategories) {
-				mockProducerRepo.EXPECT().CreatePriceCategory(priceCategory).Return(samplePriceCategory.ID, nil)
+				mockProducerRepo.EXPECT().CreatePriceCategory(priceCategory).Return(&samplePriceCategory.ID, nil)
 			},
 			expectedPriceCategoryID: true,
 			expectedError:           nil,
@@ -217,7 +216,7 @@ func TestCreateProducer(t *testing.T) {
 func TestUpdateProducer(t *testing.T) {
 
 	samplePriceCategory := &model.PriceCategories{
-		ID:           utils.NewUUID(),
+		ID:           myid.New(),
 		CategoryName: "StudentDiscount",
 		Price:        16,
 	}
@@ -242,7 +241,7 @@ func TestUpdateProducer(t *testing.T) {
 			name:          "Create priceCategory",
 			priceCategory: samplePriceCategory,
 			setExpectations: func(mockProducerRepo mocks.MockPriceCategoryRepositoryI, priceCategory *model.PriceCategories) {
-				mockProducerRepo.EXPECT().UpdatePriceCategory(priceCategory).Return(samplePriceCategory.ID, nil)
+				mockProducerRepo.EXPECT().UpdatePriceCategory(priceCategory).Return(&samplePriceCategory.ID, nil)
 			},
 			expectedPriceCategoryID: true,
 			expectedError:           nil,
@@ -285,18 +284,18 @@ func TestUpdateProducer(t *testing.T) {
 
 func TestDeleteProducer(t *testing.T) {
 
-	priceCategoryID := utils.NewUUID()
+	priceCategoryID := myid.NewUUID()
 
 	testCases := []struct {
 		name            string
-		priceCategoryID *uuid.UUID
-		setExpectations func(mockProducerRepo mocks.MockPriceCategoryRepositoryI, priceCategoryID *uuid.UUID)
+		priceCategoryID *myid.UUID
+		setExpectations func(mockProducerRepo mocks.MockPriceCategoryRepositoryI, priceCategoryID *myid.UUID)
 		expectedError   *models.KTSError
 	}{
 		{
 			name:            "priceCategory == nil",
 			priceCategoryID: nil,
-			setExpectations: func(mockProducerRepo mocks.MockPriceCategoryRepositoryI, priceCategoryID *uuid.UUID) {
+			setExpectations: func(mockProducerRepo mocks.MockPriceCategoryRepositoryI, priceCategoryID *myid.UUID) {
 
 			},
 			expectedError: kts_errors.KTS_BAD_REQUEST,
@@ -304,7 +303,7 @@ func TestDeleteProducer(t *testing.T) {
 		{
 			name:            "Create priceCategory",
 			priceCategoryID: priceCategoryID,
-			setExpectations: func(mockProducerRepo mocks.MockPriceCategoryRepositoryI, priceCategoryID *uuid.UUID) {
+			setExpectations: func(mockProducerRepo mocks.MockPriceCategoryRepositoryI, priceCategoryID *myid.UUID) {
 				mockProducerRepo.EXPECT().DeletePriceCategory(priceCategoryID).Return(nil)
 			},
 			expectedError: nil,
@@ -312,7 +311,7 @@ func TestDeleteProducer(t *testing.T) {
 		{
 			name:            "Create priceCategory fails",
 			priceCategoryID: priceCategoryID,
-			setExpectations: func(mockProducerRepo mocks.MockPriceCategoryRepositoryI, priceCategoryID *uuid.UUID) {
+			setExpectations: func(mockProducerRepo mocks.MockPriceCategoryRepositoryI, priceCategoryID *myid.UUID) {
 				mockProducerRepo.EXPECT().DeletePriceCategory(priceCategoryID).Return(kts_errors.KTS_INTERNAL_ERROR)
 			},
 			expectedError: kts_errors.KTS_INTERNAL_ERROR,

--- a/src/controllers/review_controller.go
+++ b/src/controllers/review_controller.go
@@ -4,13 +4,13 @@ import (
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/repositories"
-	"github.com/google/uuid"
 )
 
 type ReviewControllerI interface {
-	CreateReview(reviewData models.CreateReviewRequest, userId *uuid.UUID) (*model.Reviews, string, *models.KTSError)
-	DeleteReview(id *uuid.UUID, userId *uuid.UUID) *models.KTSError
+	CreateReview(reviewData models.CreateReviewRequest, userId *myid.UUID) (*model.Reviews, string, *models.KTSError)
+	DeleteReview(id *myid.UUID, userId *myid.UUID) *models.KTSError
 }
 
 type ReviewController struct {
@@ -18,26 +18,26 @@ type ReviewController struct {
 	UserRepo   repositories.UserRepositoryI
 }
 
-func (rc ReviewController) CreateReview(reviewData models.CreateReviewRequest, userId *uuid.UUID) (*model.Reviews, string, *models.KTSError) {
+func (rc ReviewController) CreateReview(reviewData models.CreateReviewRequest, userId *myid.UUID) (*model.Reviews, string, *models.KTSError) {
 	user, kts_err := rc.UserRepo.GetUserById(userId)
 	if kts_err != nil {
 		return nil, "", kts_err
 	}
 
-	id := uuid.New()
-	movieId, err := uuid.Parse(reviewData.MovieID)
+	id := myid.New()
+	movieId, err := myid.Parse(reviewData.MovieID)
 	if err != nil {
 		return nil, "", kts_errors.KTS_BAD_REQUEST
 	}
 
 	review := model.Reviews{
-		ID:        &id,
+		ID:        id,
 		Rating:    reviewData.Rating,
 		Comment:   reviewData.Comment,
 		Datetime:  reviewData.Datetime,
 		IsSpoiler: &reviewData.IsSpoiler,
-		MovieID:   &movieId,
-		UserID:    userId,
+		MovieID:   movieId,
+		UserID:    *userId,
 	}
 
 	kts_error := rc.ReviewRepo.CreateReview(review)
@@ -48,12 +48,12 @@ func (rc ReviewController) CreateReview(reviewData models.CreateReviewRequest, u
 	return &review, *user.Username, nil
 }
 
-func (rc ReviewController) DeleteReview(id *uuid.UUID, userId *uuid.UUID) *models.KTSError {
+func (rc ReviewController) DeleteReview(id *myid.UUID, userId *myid.UUID) *models.KTSError {
 	review, err := rc.ReviewRepo.GetReviewById(id)
 	if err != nil {
 		return err
 	}
-	if *review.UserID != *userId {
+	if review.UserID != *userId {
 		return kts_errors.KTS_FORBIDDEN
 	}
 	kts_error := rc.ReviewRepo.DeleteReview(id)

--- a/src/controllers/theatre_controller.go
+++ b/src/controllers/theatre_controller.go
@@ -4,15 +4,16 @@ import (
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/repositories"
-	"github.com/google/uuid"
 )
 
 type TheatreControllerI interface {
 	CreateTheatre(*models.CreateTheatreRequest) *models.KTSError
 	GetTheatres() (*[]model.Theatres, *models.KTSError)
 	CreateCinemaHall(*models.CreateCinemaHallRequest) *models.KTSError
-	GetCinemaHallsForTheatre(*uuid.UUID) (*[]model.CinemaHalls, *models.KTSError)
+	CreateCinemaHallFast(*models.CreateCinemaHallRequest) *models.KTSError
+	GetCinemaHallsForTheatre(*myid.UUID) (*[]model.CinemaHalls, *models.KTSError)
 }
 
 type TheatreController struct {
@@ -20,9 +21,9 @@ type TheatreController struct {
 }
 
 func (tc *TheatreController) CreateTheatre(theatreData *models.CreateTheatreRequest) *models.KTSError {
-	addressId := uuid.New()
+	addressId := myid.New()
 	address := model.Addresses{
-		ID:       &addressId,
+		ID:       addressId,
 		Street:   theatreData.Address.Street,
 		StreetNr: theatreData.Address.StreetNr,
 		Zipcode:  theatreData.Address.Zipcode,
@@ -35,12 +36,12 @@ func (tc *TheatreController) CreateTheatre(theatreData *models.CreateTheatreRequ
 		return kts_errors.KTS_INTERNAL_ERROR
 	}
 
-	theatreId := uuid.New()
+	theatreId := myid.New()
 	theatre := model.Theatres{
-		ID:        &theatreId,
+		ID:        theatreId,
 		Name:      theatreData.Name,
 		LogoURL:   &theatreData.LogoUrl,
-		AddressID: &addressId,
+		AddressID: addressId,
 	}
 	err = tc.TheatreRepo.CreateTheatre(theatre)
 	if err != nil {
@@ -50,22 +51,22 @@ func (tc *TheatreController) CreateTheatre(theatreData *models.CreateTheatreRequ
 	return nil
 }
 
-func (tc *TheatreController) GetTheatres() (*[]model.Theatres, *models.KTSError){
+func (tc *TheatreController) GetTheatres() (*[]model.Theatres, *models.KTSError) {
 	return tc.TheatreRepo.GetTheatres()
 }
 
 func (tc *TheatreController) CreateCinemaHall(cinemaHallData *models.CreateCinemaHallRequest) *models.KTSError {
-	cinemaHallId := uuid.New()
+	cinemaHallId := myid.New()
 
 	if !isHallValid(cinemaHallData) {
 		return kts_errors.KTS_BAD_REQUEST
 	}
 
 	cinemaHall := model.CinemaHalls{
-		ID:        &cinemaHallId,
+		ID:        cinemaHallId,
 		Name:      cinemaHallData.HallName,
 		Capacity:  computeCapacity(cinemaHallData),
-		TheatreID: cinemaHallData.TheatreId,
+		TheatreID: *cinemaHallData.TheatreId,
 	}
 
 	kts_err := tc.TheatreRepo.CreateCinemaHall(cinemaHall)
@@ -89,19 +90,19 @@ func (tc *TheatreController) CreateCinemaHall(cinemaHallData *models.CreateCinem
 				emtpy_seats++
 				visible_column--
 			}
-			seatId := uuid.New()
+			seatId := myid.New()
 			seatCategoryId, ok := seatCategoriesMap[seat.Category]
 			if !ok {
 				return kts_errors.KTS_BAD_REQUEST
 			}
 			seat := model.Seats{
-				ID:              &seatId,
+				ID:              seatId,
 				RowNr:           int32(seat.RowNr),
 				ColumnNr:        int32(seat.ColumnNr),
 				VisibleRowNr:    int32(visible_row),
 				VisibleColumnNr: int32(visible_column),
-				SeatCategoryID:  &seatCategoryId,
-				CinemaHallID:    &cinemaHallId,
+				SeatCategoryID:  seatCategoryId,
+				CinemaHallID:    cinemaHallId,
 				Type:            seat.Type,
 			}
 			kts_err = tc.TheatreRepo.CreateSeat(seat)
@@ -115,6 +116,73 @@ func (tc *TheatreController) CreateCinemaHall(cinemaHallData *models.CreateCinem
 		}
 		visible_row++
 	}
+
+	return nil
+}
+
+func (tc *TheatreController) CreateCinemaHallFast(cinemaHallData *models.CreateCinemaHallRequest) *models.KTSError {
+	cinemaHallId := myid.New()
+
+	if !isHallValid(cinemaHallData) {
+		return kts_errors.KTS_BAD_REQUEST
+	}
+
+	cinemaHall := model.CinemaHalls{
+		ID:        cinemaHallId,
+		Name:      cinemaHallData.HallName,
+		Capacity:  computeCapacity(cinemaHallData),
+		TheatreID: *cinemaHallData.TheatreId,
+	}
+
+	kts_err := tc.TheatreRepo.CreateCinemaHall(cinemaHall)
+	if kts_err != nil {
+		return kts_err
+	}
+
+	seatCategories, kts_err := tc.TheatreRepo.GetSeatCategories()
+	if kts_err != nil {
+		return kts_err
+	}
+
+	seatCategoriesMap := seatCategoriesToMap(seatCategories)
+
+	var seats []model.Seats
+	visible_row := 1
+	for _, row := range cinemaHallData.Seats {
+		visible_column := 1
+		emtpy_seats := 0
+		for _, seat := range row {
+			if seat.Type == "empty" {
+				emtpy_seats++
+				visible_column--
+			}
+			seatId := myid.New()
+			seatCategoryId, ok := seatCategoriesMap[seat.Category]
+			if !ok {
+				return kts_errors.KTS_BAD_REQUEST
+			}
+			seat := model.Seats{
+				ID:              seatId,
+				RowNr:           int32(seat.RowNr),
+				ColumnNr:        int32(seat.ColumnNr),
+				VisibleRowNr:    int32(visible_row),
+				VisibleColumnNr: int32(visible_column),
+				SeatCategoryID:  seatCategoryId,
+				CinemaHallID:    cinemaHallId,
+				Type:            seat.Type,
+			}
+			seats = append(seats, seat)
+			visible_column++
+		}
+		if emtpy_seats == len(row) {
+			continue
+		}
+		visible_row++
+	}
+			kts_err = tc.TheatreRepo.CreateSeats(seats)
+			if kts_err != nil {
+				return kts_err
+			}
 
 	return nil
 }
@@ -149,14 +217,14 @@ func computeCapacity(hall *models.CreateCinemaHallRequest) int32 {
 	return capacity
 }
 
-func seatCategoriesToMap(seatCategories []model.SeatCategories) map[string]uuid.UUID {
-	seatCategoriesMap := make(map[string]uuid.UUID)
+func seatCategoriesToMap(seatCategories []model.SeatCategories) map[string]myid.UUID {
+	seatCategoriesMap := make(map[string]myid.UUID)
 	for _, seatCategory := range seatCategories {
-		seatCategoriesMap[seatCategory.CategoryName] = *seatCategory.ID
+		seatCategoriesMap[seatCategory.CategoryName] = seatCategory.ID
 	}
 	return seatCategoriesMap
 }
 
-func (tc *TheatreController) GetCinemaHallsForTheatre(theatreId *uuid.UUID) (*[]model.CinemaHalls, *models.KTSError) {
+func (tc *TheatreController) GetCinemaHallsForTheatre(theatreId *myid.UUID) (*[]model.CinemaHalls, *models.KTSError) {
 	return tc.TheatreRepo.GetCinemaHallsForTheatre(theatreId)
 }

--- a/src/controllers/theatre_controller_test.go
+++ b/src/controllers/theatre_controller_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/mocks"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/samples"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
@@ -161,7 +161,7 @@ func TestCreateCinemaHall(t *testing.T) {
 				mockRepo.EXPECT().CreateCinemaHall(utils.EqExceptUUIDs(sampleCinemaHall)).Return(nil)
 				mockRepo.EXPECT().GetSeatCategories().Return(sampleSeatCategories, nil)
 				mockRepo.EXPECT().CreateSeat(gomock.AssignableToTypeOf(model.Seats{})).
-				Times(len(sampleRequest.Seats) * len(sampleRequest.Seats[0])).Return(nil)
+					Times(len(sampleRequest.Seats) * len(sampleRequest.Seats[0])).Return(nil)
 			},
 			expectedError: nil,
 		},
@@ -197,10 +197,10 @@ func TestCreateCinemaHall(t *testing.T) {
 
 func TestGetCinemaHallsForTheatre(t *testing.T) {
 	sampleCinemaHalls := samples.GetSampleCinemaHalls()
-	theatreId := sampleCinemaHalls[0].TheatreID
+	theatreId := &sampleCinemaHalls[0].TheatreID
 	testCases := []struct {
 		name            string
-		theatreId       *uuid.UUID
+		theatreId       *myid.UUID
 		setExpectations func(mockRepo mocks.MockTheaterRepoI)
 		expectedError   *models.KTSError
 	}{

--- a/src/controllers/ticket_controller.go
+++ b/src/controllers/ticket_controller.go
@@ -2,25 +2,25 @@ package controllers
 
 import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/repositories"
-	"github.com/google/uuid"
 )
 
 // Validate Ticket will return a struct TicketDTOValidate
 
 type TicketControllerI interface {
-	GetTicketById(id *uuid.UUID) (*models.TicketDTO, *models.KTSError)
-	ValidateTicket(id *uuid.UUID) *models.KTSError
+	GetTicketById(id *myid.UUID) (*models.TicketDTO, *models.KTSError)
+	ValidateTicket(id *myid.UUID) *models.KTSError
 }
 
 type TicketController struct {
 	TicketRepo repositories.TicketRepositoryI
 }
 
-func (tc *TicketController) GetTicketById(id *uuid.UUID) (*models.TicketDTO, *models.KTSError) {
+func (tc *TicketController) GetTicketById(id *myid.UUID) (*models.TicketDTO, *models.KTSError) {
 	return tc.TicketRepo.GetTicketById(id)
 }
 
-func (tc *TicketController) ValidateTicket(id *uuid.UUID) *models.KTSError {
+func (tc *TicketController) ValidateTicket(id *myid.UUID) *models.KTSError {
 	return tc.TicketRepo.ValidateTicket(id)
 }

--- a/src/controllers/ticket_controller_test.go
+++ b/src/controllers/ticket_controller_test.go
@@ -6,9 +6,8 @@ import (
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/mocks"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/samples"
-	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
@@ -18,13 +17,13 @@ func TestGetTicketById(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		setExpectations func(mockRepo mocks.MockTicketRepositoryI, id *uuid.UUID)
+		setExpectations func(mockRepo mocks.MockTicketRepositoryI, id *myid.UUID)
 		expectedTicket  *models.TicketDTO
 		expectedError   *models.KTSError
 	}{
 		{
 			name: "Empty result",
-			setExpectations: func(mockRepo mocks.MockTicketRepositoryI, id *uuid.UUID) {
+			setExpectations: func(mockRepo mocks.MockTicketRepositoryI, id *myid.UUID) {
 				mockRepo.EXPECT().GetTicketById(id).Return(nil, kts_errors.KTS_NOT_FOUND)
 			},
 			expectedTicket: nil,
@@ -32,7 +31,7 @@ func TestGetTicketById(t *testing.T) {
 		},
 		{
 			name: "One Ticket",
-			setExpectations: func(mockRepo mocks.MockTicketRepositoryI, id *uuid.UUID) {
+			setExpectations: func(mockRepo mocks.MockTicketRepositoryI, id *myid.UUID) {
 				mockRepo.EXPECT().GetTicketById(sampleTicket.ID).Return(sampleTicket, nil)
 			},
 			expectedTicket: sampleTicket,
@@ -40,7 +39,7 @@ func TestGetTicketById(t *testing.T) {
 		},
 		{
 			name: "Error while querying for ticket",
-			setExpectations: func(mockRepo mocks.MockTicketRepositoryI, id *uuid.UUID) {
+			setExpectations: func(mockRepo mocks.MockTicketRepositoryI, id *myid.UUID) {
 				mockRepo.EXPECT().GetTicketById(id).Return(nil, kts_errors.KTS_INTERNAL_ERROR)
 			},
 			expectedTicket: nil,
@@ -72,30 +71,30 @@ func TestGetTicketById(t *testing.T) {
 }
 
 func TestValidateTicket(t *testing.T) {
-	id := utils.NewUUID()
+	id := myid.NewUUID()
 
 	testCases := []struct {
 		name            string
-		setExpectations func(mockRepo mocks.MockTicketRepositoryI, id *uuid.UUID)
+		setExpectations func(mockRepo mocks.MockTicketRepositoryI, id *myid.UUID)
 		expectedError   *models.KTSError
 	}{
 		{
 			name: "ticket conflict",
-			setExpectations: func(mockRepo mocks.MockTicketRepositoryI, id *uuid.UUID) {
+			setExpectations: func(mockRepo mocks.MockTicketRepositoryI, id *myid.UUID) {
 				mockRepo.EXPECT().ValidateTicket(id).Return(kts_errors.KTS_CONFLICT)
 			},
 			expectedError: kts_errors.KTS_CONFLICT,
 		},
 		{
 			name: "Ticket validated",
-			setExpectations: func(mockRepo mocks.MockTicketRepositoryI, id *uuid.UUID) {
+			setExpectations: func(mockRepo mocks.MockTicketRepositoryI, id *myid.UUID) {
 				mockRepo.EXPECT().ValidateTicket(id).Return(nil)
 			},
 			expectedError: nil,
 		},
 		{
 			name: "Error while validating ticket",
-			setExpectations: func(mockRepo mocks.MockTicketRepositoryI, id *uuid.UUID) {
+			setExpectations: func(mockRepo mocks.MockTicketRepositoryI, id *myid.UUID) {
 				mockRepo.EXPECT().ValidateTicket(id).Return(kts_errors.KTS_INTERNAL_ERROR)
 			},
 			expectedError: kts_errors.KTS_INTERNAL_ERROR,

--- a/src/controllers/user_controller.go
+++ b/src/controllers/user_controller.go
@@ -4,9 +4,9 @@ import (
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/repositories"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
 )
 
 type UserControllerI interface {
@@ -21,7 +21,7 @@ type UserController struct {
 }
 
 func (uc *UserController) RegisterUser(registrationData models.RegistrationRequest) (*models.LoginResponse, *models.KTSError) {
-	userId := uuid.New()
+	userId := myid.New()
 
 	hash, err := utils.HashPassword(registrationData.Password)
 	if err != nil {
@@ -34,7 +34,7 @@ func (uc *UserController) RegisterUser(registrationData models.RegistrationReque
 	}
 
 	user := model.Users{
-		ID:        &userId,
+		ID:        userId,
 		Username:  &registrationData.Username,
 		Email:     registrationData.Email,
 		Password:  string(hash),
@@ -47,7 +47,7 @@ func (uc *UserController) RegisterUser(registrationData models.RegistrationReque
 		return nil, kts_err
 	}
 
-	token, refreshToken, err := utils.GenerateJWT(user.ID)
+	token, refreshToken, err := utils.GenerateJWT(&user.ID)
 	if err != nil {
 		return nil, kts_errors.KTS_UPSTREAM_ERROR
 	}
@@ -73,7 +73,7 @@ func (uc *UserController) LoginUser(loginData models.LoginRequest) (*models.Logi
 	}
 
 	// generate JWT token
-	token, refreshToken, err := utils.GenerateJWT(user.ID)
+	token, refreshToken, err := utils.GenerateJWT(&user.ID)
 	if err != nil {
 		return nil, kts_errors.KTS_UPSTREAM_ERROR
 	}

--- a/src/gen/KinoTicketSystem/model/actor_pictures.go
+++ b/src/gen/KinoTicketSystem/model/actor_pictures.go
@@ -8,11 +8,11 @@
 package model
 
 import (
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 type ActorPictures struct {
-	ID      *uuid.UUID `sql:"primary_key"`
-	ActorID *uuid.UUID
+	ID      myid.UUID `sql:"primary_key"`
+	ActorID myid.UUID
 	PicURL  *string
 }

--- a/src/gen/KinoTicketSystem/model/actors.go
+++ b/src/gen/KinoTicketSystem/model/actors.go
@@ -8,12 +8,12 @@
 package model
 
 import (
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"time"
 )
 
 type Actors struct {
-	ID          *uuid.UUID `sql:"primary_key"`
+	ID          myid.UUID `sql:"primary_key"`
 	Name        string
 	Birthdate   time.Time
 	Description string

--- a/src/gen/KinoTicketSystem/model/addresses.go
+++ b/src/gen/KinoTicketSystem/model/addresses.go
@@ -8,11 +8,11 @@
 package model
 
 import (
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 type Addresses struct {
-	ID       *uuid.UUID `sql:"primary_key"`
+	ID       myid.UUID `sql:"primary_key"`
 	Street   string
 	StreetNr string
 	Zipcode  string

--- a/src/gen/KinoTicketSystem/model/cinema_halls.go
+++ b/src/gen/KinoTicketSystem/model/cinema_halls.go
@@ -8,12 +8,12 @@
 package model
 
 import (
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 type CinemaHalls struct {
-	ID        *uuid.UUID `sql:"primary_key"`
+	ID        myid.UUID `sql:"primary_key"`
 	Name      string
 	Capacity  int32
-	TheatreID *uuid.UUID
+	TheatreID myid.UUID
 }

--- a/src/gen/KinoTicketSystem/model/event_movies.go
+++ b/src/gen/KinoTicketSystem/model/event_movies.go
@@ -8,10 +8,10 @@
 package model
 
 import (
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 type EventMovies struct {
-	EventID *uuid.UUID `sql:"primary_key"`
-	MovieID *uuid.UUID `sql:"primary_key"`
+	EventID myid.UUID `sql:"primary_key"`
+	MovieID myid.UUID `sql:"primary_key"`
 }

--- a/src/gen/KinoTicketSystem/model/event_seat_categories.go
+++ b/src/gen/KinoTicketSystem/model/event_seat_categories.go
@@ -8,11 +8,11 @@
 package model
 
 import (
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 type EventSeatCategories struct {
-	EventID        *uuid.UUID `sql:"primary_key"`
-	SeatCategoryID *uuid.UUID `sql:"primary_key"`
+	EventID        myid.UUID `sql:"primary_key"`
+	SeatCategoryID myid.UUID `sql:"primary_key"`
 	Price          int32
 }

--- a/src/gen/KinoTicketSystem/model/event_seats.go
+++ b/src/gen/KinoTicketSystem/model/event_seats.go
@@ -8,15 +8,15 @@
 package model
 
 import (
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"time"
 )
 
 type EventSeats struct {
-	ID           *uuid.UUID `sql:"primary_key"`
+	ID           myid.UUID `sql:"primary_key"`
 	Booked       bool
 	BlockedUntil *time.Time
-	UserID       *uuid.UUID
-	SeatID       *uuid.UUID
-	EventID      *uuid.UUID
+	UserID       *myid.UUID
+	SeatID       myid.UUID
+	EventID      myid.UUID
 }

--- a/src/gen/KinoTicketSystem/model/events.go
+++ b/src/gen/KinoTicketSystem/model/events.go
@@ -8,17 +8,17 @@
 package model
 
 import (
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"time"
 )
 
 type Events struct {
-	ID           *uuid.UUID `sql:"primary_key"`
+	ID           myid.UUID `sql:"primary_key"`
 	Title        string
 	Start        time.Time
 	End          time.Time
 	Description  *string
 	EventType    string
-	CinemaHallID *uuid.UUID
+	CinemaHallID myid.UUID
 	Is3d         bool
 }

--- a/src/gen/KinoTicketSystem/model/genres.go
+++ b/src/gen/KinoTicketSystem/model/genres.go
@@ -8,10 +8,10 @@
 package model
 
 import (
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 type Genres struct {
-	ID        *uuid.UUID `sql:"primary_key"`
+	ID        myid.UUID `sql:"primary_key"`
 	GenreName string
 }

--- a/src/gen/KinoTicketSystem/model/movie_actors.go
+++ b/src/gen/KinoTicketSystem/model/movie_actors.go
@@ -8,10 +8,10 @@
 package model
 
 import (
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 type MovieActors struct {
-	MovieID *uuid.UUID `sql:"primary_key"`
-	ActorID *uuid.UUID `sql:"primary_key"`
+	MovieID myid.UUID `sql:"primary_key"`
+	ActorID myid.UUID `sql:"primary_key"`
 }

--- a/src/gen/KinoTicketSystem/model/movie_genres.go
+++ b/src/gen/KinoTicketSystem/model/movie_genres.go
@@ -8,10 +8,10 @@
 package model
 
 import (
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 type MovieGenres struct {
-	MovieID *uuid.UUID `sql:"primary_key"`
-	GenreID *uuid.UUID `sql:"primary_key"`
+	MovieID myid.UUID `sql:"primary_key"`
+	GenreID myid.UUID `sql:"primary_key"`
 }

--- a/src/gen/KinoTicketSystem/model/movie_producers.go
+++ b/src/gen/KinoTicketSystem/model/movie_producers.go
@@ -8,10 +8,10 @@
 package model
 
 import (
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 type MovieProducers struct {
-	MovieID    *uuid.UUID `sql:"primary_key"`
-	ProducerID *uuid.UUID `sql:"primary_key"`
+	MovieID    myid.UUID `sql:"primary_key"`
+	ProducerID myid.UUID `sql:"primary_key"`
 }

--- a/src/gen/KinoTicketSystem/model/movies.go
+++ b/src/gen/KinoTicketSystem/model/movies.go
@@ -8,12 +8,12 @@
 package model
 
 import (
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"time"
 )
 
 type Movies struct {
-	ID           *uuid.UUID `sql:"primary_key"`
+	ID           myid.UUID `sql:"primary_key"`
 	Title        string
 	Description  string
 	BannerPicURL *string

--- a/src/gen/KinoTicketSystem/model/orders.go
+++ b/src/gen/KinoTicketSystem/model/orders.go
@@ -8,13 +8,13 @@
 package model
 
 import (
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 type Orders struct {
-	ID              *uuid.UUID `sql:"primary_key"`
+	ID              myid.UUID `sql:"primary_key"`
 	Totalprice      int32
 	IsPaid          bool
-	PaymentMethodID *uuid.UUID
-	UserID          *uuid.UUID
+	PaymentMethodID *myid.UUID
+	UserID          myid.UUID
 }

--- a/src/gen/KinoTicketSystem/model/payment_methods.go
+++ b/src/gen/KinoTicketSystem/model/payment_methods.go
@@ -8,10 +8,10 @@
 package model
 
 import (
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 type PaymentMethods struct {
-	ID         *uuid.UUID `sql:"primary_key"`
+	ID         myid.UUID `sql:"primary_key"`
 	Methodname string
 }

--- a/src/gen/KinoTicketSystem/model/price_categories.go
+++ b/src/gen/KinoTicketSystem/model/price_categories.go
@@ -8,11 +8,11 @@
 package model
 
 import (
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 type PriceCategories struct {
-	ID           *uuid.UUID `sql:"primary_key"`
+	ID           myid.UUID `sql:"primary_key"`
 	CategoryName string
 	Price        int32
 }

--- a/src/gen/KinoTicketSystem/model/producer_pictures.go
+++ b/src/gen/KinoTicketSystem/model/producer_pictures.go
@@ -8,11 +8,11 @@
 package model
 
 import (
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 type ProducerPictures struct {
-	ID         *uuid.UUID `sql:"primary_key"`
-	ProducerID *uuid.UUID
+	ID         myid.UUID `sql:"primary_key"`
+	ProducerID myid.UUID
 	PicURL     *string
 }

--- a/src/gen/KinoTicketSystem/model/producers.go
+++ b/src/gen/KinoTicketSystem/model/producers.go
@@ -8,12 +8,12 @@
 package model
 
 import (
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"time"
 )
 
 type Producers struct {
-	ID          *uuid.UUID `sql:"primary_key"`
+	ID          myid.UUID `sql:"primary_key"`
 	Name        string
 	Birthdate   time.Time
 	Description string

--- a/src/gen/KinoTicketSystem/model/reviews.go
+++ b/src/gen/KinoTicketSystem/model/reviews.go
@@ -8,16 +8,16 @@
 package model
 
 import (
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"time"
 )
 
 type Reviews struct {
-	ID        *uuid.UUID `sql:"primary_key"`
+	ID        myid.UUID `sql:"primary_key"`
 	Rating    int32
 	Comment   string
 	Datetime  time.Time
 	IsSpoiler *bool
-	UserID    *uuid.UUID
-	MovieID   *uuid.UUID
+	UserID    myid.UUID
+	MovieID   myid.UUID
 }

--- a/src/gen/KinoTicketSystem/model/seat_categories.go
+++ b/src/gen/KinoTicketSystem/model/seat_categories.go
@@ -8,10 +8,10 @@
 package model
 
 import (
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 type SeatCategories struct {
-	ID           *uuid.UUID `sql:"primary_key"`
+	ID           myid.UUID `sql:"primary_key"`
 	CategoryName string
 }

--- a/src/gen/KinoTicketSystem/model/seats.go
+++ b/src/gen/KinoTicketSystem/model/seats.go
@@ -8,16 +8,16 @@
 package model
 
 import (
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 type Seats struct {
-	ID              *uuid.UUID `sql:"primary_key"`
+	ID              myid.UUID `sql:"primary_key"`
 	RowNr           int32
 	ColumnNr        int32
 	VisibleRowNr    int32
 	VisibleColumnNr int32
-	SeatCategoryID  *uuid.UUID
-	CinemaHallID    *uuid.UUID
+	SeatCategoryID  myid.UUID
+	CinemaHallID    myid.UUID
 	Type            string
 }

--- a/src/gen/KinoTicketSystem/model/theatres.go
+++ b/src/gen/KinoTicketSystem/model/theatres.go
@@ -8,12 +8,12 @@
 package model
 
 import (
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 type Theatres struct {
-	ID        *uuid.UUID `sql:"primary_key"`
+	ID        myid.UUID `sql:"primary_key"`
 	Name      string
 	LogoURL   *string
-	AddressID *uuid.UUID
+	AddressID myid.UUID
 }

--- a/src/gen/KinoTicketSystem/model/tickets.go
+++ b/src/gen/KinoTicketSystem/model/tickets.go
@@ -8,14 +8,14 @@
 package model
 
 import (
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 type Tickets struct {
-	ID              *uuid.UUID `sql:"primary_key"`
+	ID              myid.UUID `sql:"primary_key"`
 	Validated       bool
 	Price           int32
-	PriceCategoryID *uuid.UUID
-	OrderID         *uuid.UUID
-	EventSeatID     *uuid.UUID
+	PriceCategoryID myid.UUID
+	OrderID         myid.UUID
+	EventSeatID     myid.UUID
 }

--- a/src/gen/KinoTicketSystem/model/user_movies.go
+++ b/src/gen/KinoTicketSystem/model/user_movies.go
@@ -8,11 +8,11 @@
 package model
 
 import (
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 type UserMovies struct {
-	UserID   *uuid.UUID `sql:"primary_key"`
-	MovieID  *uuid.UUID `sql:"primary_key"`
-	ListType string     `sql:"primary_key"`
+	UserID   myid.UUID `sql:"primary_key"`
+	MovieID  myid.UUID `sql:"primary_key"`
+	ListType string    `sql:"primary_key"`
 }

--- a/src/gen/KinoTicketSystem/model/users.go
+++ b/src/gen/KinoTicketSystem/model/users.go
@@ -8,11 +8,11 @@
 package model
 
 import (
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 type Users struct {
-	ID        *uuid.UUID `sql:"primary_key"`
+	ID        myid.UUID `sql:"primary_key"`
 	Username  *string
 	Email     string
 	Password  string `json:"-"`

--- a/src/handlers/actor_handler.go
+++ b/src/handlers/actor_handler.go
@@ -6,9 +6,9 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/controllers"
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 )
 
 // @Summary Get actor by id
@@ -24,7 +24,7 @@ import (
 // @Router /actors/{id} [get]
 func GetActorByIdHandler(actorController controllers.ActorControllerI) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		actorId, err := uuid.Parse(c.Param("id"))
+		actorId, err := myid.Parse(c.Param("id"))
 		if err != nil {
 			utils.HandleErrorAndAbort(c, kts_errors.KTS_BAD_REQUEST)
 			return
@@ -65,7 +65,7 @@ func GetActorsHandler(actorController controllers.ActorControllerI) gin.HandlerF
 // @Accept  json
 // @Produce  json
 // @Param actor body models.CreateActorDTO true "Actor"
-// @Success 201 {object} uuid.UUID
+// @Success 201 {object} myid.UUID
 // @Failure 400 {object} models.KTSErrorMessage
 // @Failure 500 {object} models.KTSErrorMessage
 // @Router /actors [post]

--- a/src/handlers/actor_handler_test.go
+++ b/src/handlers/actor_handler_test.go
@@ -152,7 +152,7 @@ func TestCreateActorHandler(t *testing.T) {
 			name: "Success",
 			body: sampleCreateActor,
 			setExpectations: func(mockController *mocks.MockActorControllerI, actor interface{}) {
-				mockController.EXPECT().CreateActor(gomock.Any()).Return(sampleCreateActor.ID, nil)
+				mockController.EXPECT().CreateActor(gomock.Any()).Return(&sampleCreateActor.ID, nil)
 			},
 			expectedStatus: http.StatusCreated,
 			expectedBody:   sampleCreateActor.ID,

--- a/src/handlers/event_handler.go
+++ b/src/handlers/event_handler.go
@@ -6,9 +6,9 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/controllers"
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 )
 
 // @Summary Create event
@@ -17,7 +17,7 @@ import (
 // @Accept  json
 // @Produce  json
 // @Param event body models.CreateEvtDTO true "Event data"
-// @Success 200 {array} uuid.UUID
+// @Success 200 {array} myid.UUID
 // @Failure 500 {object} string
 // @Failure 400 {object} models.KTSErrorMessage
 // @Router /events [post]
@@ -50,12 +50,12 @@ func CreateEventHandler(eventController controllers.EventControllerI) gin.Handle
 // @Router /movies/{id}/events [get]
 func GetEventsForMovieHandler(eventController controllers.EventControllerI) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		movieId, err := uuid.Parse(c.Param("id"))
+		movieId, err := myid.Parse(c.Param("id"))
 		if err != nil {
 			utils.HandleErrorAndAbort(c, kts_errors.KTS_BAD_REQUEST)
 			return
 		}
-		theatreId, err := uuid.Parse(c.Param("theatreId"))
+		theatreId, err := myid.Parse(c.Param("theatreId"))
 		if err != nil {
 			utils.HandleErrorAndAbort(c, kts_errors.KTS_BAD_REQUEST)
 			return
@@ -102,7 +102,7 @@ func GetSpecialEventsHandler(eventController controllers.EventControllerI) gin.H
 // @Router /events/{eventId} [get]
 func GetEventByIdHandler(eventController controllers.EventControllerI) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		id, err := uuid.Parse(c.Param("eventId"))
+		id, err := myid.Parse(c.Param("eventId"))
 		if err != nil {
 			utils.HandleErrorAndAbort(c, kts_errors.KTS_BAD_REQUEST)
 			return

--- a/src/handlers/event_handler_test.go
+++ b/src/handlers/event_handler_test.go
@@ -8,15 +8,15 @@ import (
 
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/mocks"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/samples"
-	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
 
 func TestGetEventByIdHandler(t *testing.T) {
-	eventId := utils.NewUUID()
+	eventId := myid.NewUUID()
 	event := samples.GetGetSpecialEventsDTO(eventId)
 
 	eventJson, _ := json.Marshal(event)
@@ -89,8 +89,8 @@ func TestGetEventByIdHandler(t *testing.T) {
 	}
 }
 func TestGetEventsForMovieHandler(t *testing.T) {
-	movieId := utils.NewUUID()
-	theatreId := utils.NewUUID()
+	movieId := myid.NewUUID()
+	theatreId := myid.NewUUID()
 
 	events := samples.GetModelEvents()
 

--- a/src/handlers/eventseat_handler.go
+++ b/src/handlers/eventseat_handler.go
@@ -6,9 +6,9 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/controllers"
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 )
 
 // @Summary Get event seats
@@ -24,14 +24,14 @@ import (
 // @Router /events/{eventId}/seats [get]
 func GetEventSeatsHandler(eventSeatController controllers.EventSeatControllerI) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		eventSeatId, err := uuid.Parse(c.Param("eventId"))
+		eventSeatId, err := myid.Parse(c.Param("eventId"))
 
 		if err != nil {
 			utils.HandleErrorAndAbort(c, kts_errors.KTS_BAD_REQUEST)
 			return
 		}
 
-		userId := c.Request.Context().Value(models.ContextKeyUserID).(*uuid.UUID)
+		userId := c.Request.Context().Value(models.ContextKeyUserID).(*myid.UUID)
 
 		seatMap, currentUserSeats, blockedUntil, kts_err := eventSeatController.GetEventSeats(&eventSeatId, userId)
 		if kts_err != nil {
@@ -60,21 +60,21 @@ func GetEventSeatsHandler(eventSeatController controllers.EventSeatControllerI) 
 // @Router /events/{eventId}/seats/{seatId}/block [patch]
 func BlockEventSeatHandler(eventSeatController controllers.EventSeatControllerI) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		eventId, err := uuid.Parse(c.Param("eventId"))
+		eventId, err := myid.Parse(c.Param("eventId"))
 
 		if err != nil {
 			utils.HandleErrorAndAbort(c, kts_errors.KTS_BAD_REQUEST)
 			return
 		}
 
-		eventSeatId, err := uuid.Parse(c.Param("seatId"))
+		eventSeatId, err := myid.Parse(c.Param("seatId"))
 
 		if err != nil {
 			utils.HandleErrorAndAbort(c, kts_errors.KTS_BAD_REQUEST)
 			return
 		}
 
-		userId := c.Request.Context().Value(models.ContextKeyUserID).(*uuid.UUID)
+		userId := c.Request.Context().Value(models.ContextKeyUserID).(*myid.UUID)
 
 		blockedUntil, kts_err := eventSeatController.BlockEventSeat(&eventId, &eventSeatId, userId)
 		if kts_err != nil {
@@ -102,21 +102,21 @@ func BlockEventSeatHandler(eventSeatController controllers.EventSeatControllerI)
 // @Router /events/{eventId}/seats/{seatId}/unblock [patch]
 func UnblockEventSeatHandler(eventSeatController controllers.EventSeatControllerI) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		eventId, err := uuid.Parse(c.Param("eventId"))
+		eventId, err := myid.Parse(c.Param("eventId"))
 
 		if err != nil {
 			utils.HandleErrorAndAbort(c, kts_errors.KTS_BAD_REQUEST)
 			return
 		}
 
-		eventSeatId, err := uuid.Parse(c.Param("seatId"))
+		eventSeatId, err := myid.Parse(c.Param("seatId"))
 
 		if err != nil {
 			utils.HandleErrorAndAbort(c, kts_errors.KTS_BAD_REQUEST)
 			return
 		}
 
-		userId := c.Request.Context().Value(models.ContextKeyUserID).(*uuid.UUID)
+		userId := c.Request.Context().Value(models.ContextKeyUserID).(*myid.UUID)
 
 		blockedUntil, kts_err := eventSeatController.UnblockEventSeat(&eventId, &eventSeatId, userId)
 		if kts_err != nil {
@@ -132,14 +132,14 @@ func UnblockEventSeatHandler(eventSeatController controllers.EventSeatController
 
 func UnblockAllEventSeatsHandler(eventSeatController controllers.EventSeatControllerI) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		eventId, err := uuid.Parse(c.Param("eventId"))
+		eventId, err := myid.Parse(c.Param("eventId"))
 
 		if err != nil {
 			utils.HandleErrorAndAbort(c, kts_errors.KTS_BAD_REQUEST)
 			return
 		}
 
-		userId := c.Request.Context().Value(models.ContextKeyUserID).(*uuid.UUID)
+		userId := c.Request.Context().Value(models.ContextKeyUserID).(*myid.UUID)
 
 		kts_err := eventSeatController.UnblockAllEventSeats(&eventId, userId)
 		if kts_err != nil {
@@ -165,14 +165,14 @@ func UnblockAllEventSeatsHandler(eventSeatController controllers.EventSeatContro
 // @Router /events/{eventId}/user-seats [get]
 func GetSelectedSeatsHandler(eventSeatController controllers.EventSeatControllerI) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		eventId, err := uuid.Parse(c.Param("eventId"))
+		eventId, err := myid.Parse(c.Param("eventId"))
 
 		if err != nil {
 			utils.HandleErrorAndAbort(c, kts_errors.KTS_BAD_REQUEST)
 			return
 		}
 
-		userId := c.Request.Context().Value(models.ContextKeyUserID).(*uuid.UUID)
+		userId := c.Request.Context().Value(models.ContextKeyUserID).(*myid.UUID)
 
 		selectedSeats, kts_err := eventSeatController.GetSelectedSeats(&eventId, userId)
 		if kts_err != nil {

--- a/src/handlers/eventseat_handler_test.go
+++ b/src/handlers/eventseat_handler_test.go
@@ -13,9 +13,8 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/handlers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/mocks"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
@@ -23,15 +22,15 @@ import (
 func TestGetEventSeatsHandler(t *testing.T) {
 	testCases := []struct {
 		name                 string
-		paramId              *uuid.UUID
-		setExpectations      func(mockController *mocks.MockEventSeatControllerI, eventSeatId *uuid.UUID, userId *uuid.UUID)
+		paramId              *myid.UUID
+		setExpectations      func(mockController *mocks.MockEventSeatControllerI, eventSeatId *myid.UUID, userId *myid.UUID)
 		expectedResponseBody gin.H
 		expectedStatus       int
 	}{
 		{
 			name:    "Success",
-			paramId: utils.NewUUID(),
-			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventSeatId *uuid.UUID, userId *uuid.UUID) {
+			paramId: myid.NewUUID(),
+			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventSeatId *myid.UUID, userId *myid.UUID) {
 				mockController.EXPECT().GetEventSeats(gomock.Any(), gomock.Any()).Return(
 
 					&[][]models.GetSeatsForSeatSelectorDTO{},
@@ -48,8 +47,8 @@ func TestGetEventSeatsHandler(t *testing.T) {
 		},
 		{
 			name:    "Internal error",
-			paramId: utils.NewUUID(),
-			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventSeatId *uuid.UUID, userId *uuid.UUID) {
+			paramId: myid.NewUUID(),
+			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventSeatId *myid.UUID, userId *myid.UUID) {
 				mockController.EXPECT().GetEventSeats(gomock.Any(), gomock.Any()).Return(
 					nil,
 					nil,
@@ -63,8 +62,8 @@ func TestGetEventSeatsHandler(t *testing.T) {
 		},
 		{
 			name:    "Event seat not found",
-			paramId: utils.NewUUID(),
-			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventSeatId *uuid.UUID, userId *uuid.UUID) {
+			paramId: myid.NewUUID(),
+			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventSeatId *myid.UUID, userId *myid.UUID) {
 				mockController.EXPECT().GetEventSeats(gomock.Any(), gomock.Any()).Return(
 					nil,
 					nil,
@@ -92,8 +91,8 @@ func TestGetEventSeatsHandler(t *testing.T) {
 			defer mockCtrl.Finish()
 			eventSeatController := mocks.NewMockEventSeatControllerI(mockCtrl)
 
-			userId := utils.NewUUID()
-			id := uuid.New()
+			userId := myid.NewUUID()
+			id := myid.New()
 			c.Params = []gin.Param{{Key: "eventId", Value: id.String()}}
 
 			ctx := context.WithValue(c.Request.Context(), models.ContextKeyUserID, userId)
@@ -119,17 +118,17 @@ func TestBlockEventSeatHandler(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		paramEventId    *uuid.UUID
-		paramSeatId     *uuid.UUID
-		setExpectations func(mockController *mocks.MockEventSeatControllerI, eventId *uuid.UUID, eventSeatId *uuid.UUID, userId *uuid.UUID)
+		paramEventId    *myid.UUID
+		paramSeatId     *myid.UUID
+		setExpectations func(mockController *mocks.MockEventSeatControllerI, eventId *myid.UUID, eventSeatId *myid.UUID, userId *myid.UUID)
 		expectedStatus  int
 		expectedBody    string
 	}{
 		{
 			name:         "Success",
-			paramEventId: utils.NewUUID(),
-			paramSeatId:  utils.NewUUID(),
-			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventId *uuid.UUID, eventSeatId *uuid.UUID, userId *uuid.UUID) {
+			paramEventId: myid.NewUUID(),
+			paramSeatId:  myid.NewUUID(),
+			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventId *myid.UUID, eventSeatId *myid.UUID, userId *myid.UUID) {
 				mockController.EXPECT().BlockEventSeat(gomock.Any(), gomock.Any(), gomock.Any()).Return(&resTime, nil)
 			},
 			expectedStatus: http.StatusOK,
@@ -137,9 +136,9 @@ func TestBlockEventSeatHandler(t *testing.T) {
 		},
 		{
 			name:         "Internal error",
-			paramEventId: utils.NewUUID(),
-			paramSeatId:  utils.NewUUID(),
-			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventId *uuid.UUID, eventSeatId *uuid.UUID, userId *uuid.UUID) {
+			paramEventId: myid.NewUUID(),
+			paramSeatId:  myid.NewUUID(),
+			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventId *myid.UUID, eventSeatId *myid.UUID, userId *myid.UUID) {
 				mockController.EXPECT().BlockEventSeat(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, kts_errors.KTS_INTERNAL_ERROR)
 			},
 			expectedStatus: http.StatusInternalServerError,
@@ -147,9 +146,9 @@ func TestBlockEventSeatHandler(t *testing.T) {
 		},
 		{
 			name:         "Event seat not found",
-			paramEventId: utils.NewUUID(),
-			paramSeatId:  utils.NewUUID(),
-			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventId *uuid.UUID, eventSeatId *uuid.UUID, userId *uuid.UUID) {
+			paramEventId: myid.NewUUID(),
+			paramSeatId:  myid.NewUUID(),
+			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventId *myid.UUID, eventSeatId *myid.UUID, userId *myid.UUID) {
 				mockController.EXPECT().BlockEventSeat(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, kts_errors.KTS_NOT_FOUND)
 			},
 			expectedStatus: http.StatusNotFound,
@@ -157,9 +156,9 @@ func TestBlockEventSeatHandler(t *testing.T) {
 		},
 		{
 			name:         "Event seat already booked",
-			paramEventId: utils.NewUUID(),
-			paramSeatId:  utils.NewUUID(),
-			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventId *uuid.UUID, eventSeatId *uuid.UUID, userId *uuid.UUID) {
+			paramEventId: myid.NewUUID(),
+			paramSeatId:  myid.NewUUID(),
+			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventId *myid.UUID, eventSeatId *myid.UUID, userId *myid.UUID) {
 				mockController.EXPECT().BlockEventSeat(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, kts_errors.KTS_CONFLICT)
 			},
 			expectedStatus: http.StatusConflict,
@@ -177,7 +176,7 @@ func TestBlockEventSeatHandler(t *testing.T) {
 			c.Request = req
 			c.Params = []gin.Param{{Key: "eventId", Value: tc.paramEventId.String()}, {Key: "seatId", Value: tc.paramSeatId.String()}}
 
-			userId := utils.NewUUID()
+			userId := myid.NewUUID()
 
 			ctx := context.WithValue(c.Request.Context(), models.ContextKeyUserID, userId)
 			c.Request = c.Request.WithContext(ctx)
@@ -205,17 +204,17 @@ func TestUnblockEventSeatHandler(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		paramEventId    *uuid.UUID
-		paramSeatId     *uuid.UUID
-		setExpectations func(mockController *mocks.MockEventSeatControllerI, eventId *uuid.UUID, eventSeatId *uuid.UUID, userId *uuid.UUID)
+		paramEventId    *myid.UUID
+		paramSeatId     *myid.UUID
+		setExpectations func(mockController *mocks.MockEventSeatControllerI, eventId *myid.UUID, eventSeatId *myid.UUID, userId *myid.UUID)
 		expectedStatus  int
 		expectedBody    string
 	}{
 		{
 			name:         "Success",
-			paramEventId: utils.NewUUID(),
-			paramSeatId:  utils.NewUUID(),
-			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventId *uuid.UUID, eventSeatId *uuid.UUID, userId *uuid.UUID) {
+			paramEventId: myid.NewUUID(),
+			paramSeatId:  myid.NewUUID(),
+			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventId *myid.UUID, eventSeatId *myid.UUID, userId *myid.UUID) {
 				mockController.EXPECT().UnblockEventSeat(gomock.Any(), gomock.Any(), gomock.Any()).Return(&resTime, nil)
 			},
 			expectedStatus: http.StatusOK,
@@ -223,9 +222,9 @@ func TestUnblockEventSeatHandler(t *testing.T) {
 		},
 		{
 			name:         "Internal error",
-			paramEventId: utils.NewUUID(),
-			paramSeatId:  utils.NewUUID(),
-			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventId *uuid.UUID, eventSeatId *uuid.UUID, userId *uuid.UUID) {
+			paramEventId: myid.NewUUID(),
+			paramSeatId:  myid.NewUUID(),
+			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventId *myid.UUID, eventSeatId *myid.UUID, userId *myid.UUID) {
 				mockController.EXPECT().UnblockEventSeat(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, kts_errors.KTS_INTERNAL_ERROR)
 			},
 			expectedStatus: http.StatusInternalServerError,
@@ -233,9 +232,9 @@ func TestUnblockEventSeatHandler(t *testing.T) {
 		},
 		{
 			name:         "Event seat not found",
-			paramEventId: utils.NewUUID(),
-			paramSeatId:  utils.NewUUID(),
-			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventId *uuid.UUID, eventSeatId *uuid.UUID, userId *uuid.UUID) {
+			paramEventId: myid.NewUUID(),
+			paramSeatId:  myid.NewUUID(),
+			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventId *myid.UUID, eventSeatId *myid.UUID, userId *myid.UUID) {
 				mockController.EXPECT().UnblockEventSeat(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, kts_errors.KTS_NOT_FOUND)
 			},
 			expectedStatus: http.StatusNotFound,
@@ -253,7 +252,7 @@ func TestUnblockEventSeatHandler(t *testing.T) {
 			c.Request = req
 			c.Params = []gin.Param{{Key: "eventId", Value: tc.paramEventId.String()}, {Key: "seatId", Value: tc.paramSeatId.String()}}
 
-			userId := utils.NewUUID()
+			userId := myid.NewUUID()
 
 			ctx := context.WithValue(c.Request.Context(), models.ContextKeyUserID, userId)
 			c.Request = c.Request.WithContext(ctx)
@@ -276,15 +275,15 @@ func TestUnblockEventSeatHandler(t *testing.T) {
 func TestGetSelectedSeatsHandler(t *testing.T) {
 	testCases := []struct {
 		name                 string
-		paramEventId         *uuid.UUID
-		setExpectations      func(mockController *mocks.MockEventSeatControllerI, eventId *uuid.UUID, userId *uuid.UUID)
+		paramEventId         *myid.UUID
+		setExpectations      func(mockController *mocks.MockEventSeatControllerI, eventId *myid.UUID, userId *myid.UUID)
 		expectedResponseBody gin.H
 		expectedStatus       int
 	}{
 		{
 			name:         "Success",
-			paramEventId: utils.NewUUID(),
-			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventId *uuid.UUID, userId *uuid.UUID) {
+			paramEventId: myid.NewUUID(),
+			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventId *myid.UUID, userId *myid.UUID) {
 				mockController.EXPECT().GetSelectedSeats(gomock.Any(), gomock.Any()).Return(
 					&[]models.GetSlectedSeatsDTO{},
 					nil,
@@ -297,8 +296,8 @@ func TestGetSelectedSeatsHandler(t *testing.T) {
 		},
 		{
 			name:         "Bad request",
-			paramEventId: utils.NewUUID(),
-			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventId *uuid.UUID, userId *uuid.UUID) {
+			paramEventId: myid.NewUUID(),
+			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventId *myid.UUID, userId *myid.UUID) {
 				mockController.EXPECT().GetSelectedSeats(gomock.Any(), gomock.Any()).Return(
 					nil,
 					kts_errors.KTS_BAD_REQUEST,
@@ -311,8 +310,8 @@ func TestGetSelectedSeatsHandler(t *testing.T) {
 		},
 		{
 			name:         "Internal error",
-			paramEventId: utils.NewUUID(),
-			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventId *uuid.UUID, userId *uuid.UUID) {
+			paramEventId: myid.NewUUID(),
+			setExpectations: func(mockController *mocks.MockEventSeatControllerI, eventId *myid.UUID, userId *myid.UUID) {
 				mockController.EXPECT().GetSelectedSeats(gomock.Any(), gomock.Any()).Return(
 					nil,
 					kts_errors.KTS_INTERNAL_ERROR,
@@ -335,7 +334,7 @@ func TestGetSelectedSeatsHandler(t *testing.T) {
 			c.Request = req
 			c.Params = []gin.Param{{Key: "eventId", Value: tc.paramEventId.String()}}
 
-			userId := utils.NewUUID()
+			userId := myid.NewUUID()
 
 			ctx := context.WithValue(c.Request.Context(), models.ContextKeyUserID, userId)
 			c.Request = c.Request.WithContext(ctx)

--- a/src/handlers/genre_handler.go
+++ b/src/handlers/genre_handler.go
@@ -6,9 +6,9 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/controllers"
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 )
 
 // @Summary Get genres
@@ -126,7 +126,7 @@ func UpdateGenre(genreCtrl controllers.GenreControllerI) gin.HandlerFunc {
 // @Router /genres/{id} [delete]
 func DeleteGenre(genreCtrl controllers.GenreControllerI) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		genreId, err := uuid.Parse(c.Param("id"))
+		genreId, err := myid.Parse(c.Param("id"))
 		if err != nil {
 			utils.HandleErrorAndAbort(c, kts_errors.KTS_BAD_REQUEST)
 			return

--- a/src/handlers/genre_handler_test.go
+++ b/src/handlers/genre_handler_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/handlers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/mocks"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/samples"
-	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -90,7 +90,7 @@ func TestUpdateGenreHandler(t *testing.T) {
 }
 
 func TestDeleteGenreHandler(t *testing.T) {
-	sampleUpdateGenreId := utils.NewUUID()
+	sampleUpdateGenreId := myid.NewUUID()
 
 	testCases := []struct {
 		name            string
@@ -293,7 +293,7 @@ func TestCreateGenreHandler(t *testing.T) {
 			name:      "Success",
 			genreName: genreName,
 			setExpectations: func(mockController *mocks.MockGenreControllerI, genreName string) {
-				mockController.EXPECT().CreateGenre(gomock.Any()).Return(genreId, nil)
+				mockController.EXPECT().CreateGenre(gomock.Any()).Return(&genreId, nil)
 			},
 			expectedStatus: http.StatusCreated,
 			expectedBody:   genreId,
@@ -346,7 +346,6 @@ func TestCreateGenreHandler(t *testing.T) {
 		})
 	}
 }
-
 
 func TestGetGenresWithMoviesHandler(t *testing.T) {
 	sampleGenreWithMovie := samples.GetSampleGenresWithMovies()

--- a/src/handlers/movie_handler.go
+++ b/src/handlers/movie_handler.go
@@ -8,9 +8,9 @@ import (
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 )
 
 // @Summary Get movies
@@ -38,7 +38,7 @@ func GetMovies(movieCtrl controllers.MovieControllerI) gin.HandlerFunc {
 // @Accept  json
 // @Produce  json
 // @Param movie body models.MovieDTOCreate true "Movie data"
-// @Success 200 {object} uuid.UUID
+// @Success 200 {object} myid.UUID
 // @Failure 500 {object} models.KTSErrorMessage
 // @Router /movies [post]
 func CreateMovie(movieCtrl controllers.MovieControllerI) gin.HandlerFunc {
@@ -134,7 +134,7 @@ func UpdateMovie(movieCtrl controllers.MovieControllerI) gin.HandlerFunc {
 // @Router /movies/{id} [delete]
 func DeleteMovie(movieCtrl controllers.MovieControllerI) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		movieId, err := uuid.Parse(c.Param("movieId"))
+		movieId, err := myid.Parse(c.Param("movieId"))
 
 		if err != nil {
 			utils.HandleErrorAndAbort(c, kts_errors.KTS_BAD_REQUEST)
@@ -182,7 +182,7 @@ func GetMoviesWithGenres(movieCtrl controllers.MovieControllerI) gin.HandlerFunc
 // @Router /movies/{id} [get]
 func GetMovieById(movieCtrl controllers.MovieControllerI) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		movieId, err := uuid.Parse(c.Param("id"))
+		movieId, err := myid.Parse(c.Param("id"))
 		if err != nil {
 			utils.HandleErrorAndAbort(c, kts_errors.KTS_BAD_REQUEST)
 			return

--- a/src/handlers/movie_handler_test.go
+++ b/src/handlers/movie_handler_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/handlers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/mocks"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/samples"
-	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -100,7 +100,7 @@ func TestUpdateMovieHandler(t *testing.T) {
 }
 
 func TestDeleteMovieHandler(t *testing.T) {
-	sampleUpdateMovieId := utils.NewUUID()
+	sampleUpdateMovieId := myid.NewUUID()
 
 	testCases := []struct {
 		name            string
@@ -355,7 +355,7 @@ func TestCreateMovieHandler(t *testing.T) {
 			name: "Success",
 			body: sampleCreateMovie,
 			setExpectations: func(mockController *mocks.MockMovieControllerI, movieData interface{}) {
-				mockController.EXPECT().CreateMovie(gomock.Any()).Return(sampleCreateMovie.ID, nil)
+				mockController.EXPECT().CreateMovie(gomock.Any()).Return(&sampleCreateMovie.ID, nil)
 			},
 			expectedStatus: http.StatusCreated,
 			expectedBody:   sampleCreateMovie.ID,

--- a/src/handlers/order_handler.go
+++ b/src/handlers/order_handler.go
@@ -6,9 +6,9 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/controllers"
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 )
 
 // User has to be logged in
@@ -26,14 +26,14 @@ import (
 // @Router /events/{eventId}/book [post]
 func CreateOrderHandler(orderController controllers.OrderControllerI, isReservation bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		eventId, err := uuid.Parse(c.Param("eventId"))
+		eventId, err := myid.Parse(c.Param("eventId"))
 
 		if err != nil {
 			utils.HandleErrorAndAbort(c, kts_errors.KTS_BAD_REQUEST)
 			return
 		}
 
-		userId := c.Request.Context().Value(models.ContextKeyUserID).(*uuid.UUID)
+		userId := c.Request.Context().Value(models.ContextKeyUserID).(*myid.UUID)
 
 		createOrderDTO := models.CreateOrderDTO{}
 
@@ -69,14 +69,14 @@ func CreateOrderHandler(orderController controllers.OrderControllerI, isReservat
 // @Router /orders/{orderId} [get]
 func GetOrderByIdHandler(orderController controllers.OrderControllerI) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		orderId, err := uuid.Parse(c.Param("orderId"))
+		orderId, err := myid.Parse(c.Param("orderId"))
 
 		if err != nil {
 			utils.HandleErrorAndAbort(c, kts_errors.KTS_BAD_REQUEST)
 			return
 		}
 
-		userId := c.Request.Context().Value(models.ContextKeyUserID).(*uuid.UUID)
+		userId := c.Request.Context().Value(models.ContextKeyUserID).(*myid.UUID)
 
 		order, kts_err := orderController.GetOrderById(&orderId, userId)
 
@@ -99,7 +99,7 @@ func GetOrderByIdHandler(orderController controllers.OrderControllerI) gin.Handl
 // @Router /orders [get]
 func GetOrdersHandler(orderController controllers.OrderControllerI) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		userId := c.Request.Context().Value(models.ContextKeyUserID).(*uuid.UUID)
+		userId := c.Request.Context().Value(models.ContextKeyUserID).(*myid.UUID)
 
 		orders, kts_err := orderController.GetOrders(userId)
 

--- a/src/handlers/order_handler_test.go
+++ b/src/handlers/order_handler_test.go
@@ -13,28 +13,27 @@ import (
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/mocks"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/samples"
-	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
 
 func TestCreateOrderHandler(t *testing.T) {
-	orderId := utils.NewUUID()
+	orderId := myid.NewUUID()
 	tests := []struct {
 		name                 string
-		paramEventId         *uuid.UUID
-		setExpectations      func(mockOrderController *mocks.MockOrderControllerI, eventId *uuid.UUID, userId *uuid.UUID)
+		paramEventId         *myid.UUID
+		setExpectations      func(mockOrderController *mocks.MockOrderControllerI, eventId *myid.UUID, userId *myid.UUID)
 		expectedResponseBody gin.H
 		expectedStatus       int
 		createOrderDTO       *models.CreateOrderDTO
 	}{
 		{
 			name:         "Success",
-			paramEventId: utils.NewUUID(),
-			setExpectations: func(mockOrderController *mocks.MockOrderControllerI, eventId *uuid.UUID, userId *uuid.UUID) {
+			paramEventId: myid.NewUUID(),
+			setExpectations: func(mockOrderController *mocks.MockOrderControllerI, eventId *myid.UUID, userId *myid.UUID) {
 				mockOrderController.EXPECT().CreateOrder(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
 					orderId,
 					nil,
@@ -48,8 +47,8 @@ func TestCreateOrderHandler(t *testing.T) {
 		},
 		{
 			name:         "Bad Request",
-			paramEventId: utils.NewUUID(),
-			setExpectations: func(mockOrderController *mocks.MockOrderControllerI, eventId *uuid.UUID, userId *uuid.UUID) {
+			paramEventId: myid.NewUUID(),
+			setExpectations: func(mockOrderController *mocks.MockOrderControllerI, eventId *myid.UUID, userId *myid.UUID) {
 				mockOrderController.EXPECT().CreateOrder(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
 					nil,
 					kts_errors.KTS_INTERNAL_ERROR,
@@ -74,7 +73,7 @@ func TestCreateOrderHandler(t *testing.T) {
 			c.Request = req
 			c.Params = []gin.Param{{Key: "eventId", Value: tc.paramEventId.String()}}
 
-			userId := utils.NewUUID()
+			userId := myid.NewUUID()
 
 			ctx := context.WithValue(c.Request.Context(), models.ContextKeyUserID, userId)
 			c.Request = c.Request.WithContext(ctx)
@@ -106,14 +105,14 @@ func TestGetOrderById(t *testing.T) {
 	orderJson, _ := json.Marshal(order)
 	tests := []struct {
 		name               string
-		paramOrderId       *uuid.UUID
+		paramOrderId       *myid.UUID
 		setExpectations    func(mockOrderController *mocks.MockOrderControllerI)
 		expectedStatus     int
 		ExpectedBodyString string
 	}{
 		{
 			name:         "Success",
-			paramOrderId: utils.NewUUID(),
+			paramOrderId: myid.NewUUID(),
 			setExpectations: func(mockOrderController *mocks.MockOrderControllerI) {
 				mockOrderController.EXPECT().GetOrderById(gomock.Any(), gomock.Any()).Return(
 					order,
@@ -125,7 +124,7 @@ func TestGetOrderById(t *testing.T) {
 		},
 		{
 			name:         "Bad Request",
-			paramOrderId: utils.NewUUID(),
+			paramOrderId: myid.NewUUID(),
 			setExpectations: func(mockOrderController *mocks.MockOrderControllerI) {
 				mockOrderController.EXPECT().GetOrderById(gomock.Any(), gomock.Any()).Return(
 					nil,
@@ -148,7 +147,7 @@ func TestGetOrderById(t *testing.T) {
 			c.Request = req
 			c.Params = []gin.Param{{Key: "orderId", Value: tc.paramOrderId.String()}}
 
-			userId := utils.NewUUID()
+			userId := myid.NewUUID()
 
 			ctx := context.WithValue(c.Request.Context(), models.ContextKeyUserID, userId)
 			c.Request = c.Request.WithContext(ctx)
@@ -213,7 +212,7 @@ func TestGetOrders(t *testing.T) {
 			c, _ := gin.CreateTestContext(w)
 			c.Request = req
 
-			userId := utils.NewUUID()
+			userId := myid.NewUUID()
 
 			ctx := context.WithValue(c.Request.Context(), models.ContextKeyUserID, userId)
 			c.Request = c.Request.WithContext(ctx)

--- a/src/handlers/price_category_handler.go
+++ b/src/handlers/price_category_handler.go
@@ -6,9 +6,9 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/controllers"
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 )
 
 // @Summary Get price category by id
@@ -22,7 +22,7 @@ import (
 // @Router /price-categories/{id} [get]
 func GetPriceCategoryByIdHandler(priceCategoriesController controllers.PriceCategoryControllerI) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		priceCategoryId, err := uuid.Parse(c.Param("id"))
+		priceCategoryId, err := myid.Parse(c.Param("id"))
 		if err != nil {
 			utils.HandleErrorAndAbort(c, kts_errors.KTS_BAD_REQUEST)
 			return
@@ -63,7 +63,7 @@ func GetPriceCategoriesHandler(priceCategoriesController controllers.PriceCatego
 // @Accept  json
 // @Produce  json
 // @Param priceCategory body model.PriceCategories true "Price category data"
-// @Success 200 {object} uuid.UUID
+// @Success 200 {object} myid.UUID
 // @Failure 500 {object} models.KTSErrorMessage
 // @Router /price-categories [post]
 func CreatePriceCategoryHandler(priceCategoriesController controllers.PriceCategoryControllerI) gin.HandlerFunc {
@@ -91,7 +91,7 @@ func CreatePriceCategoryHandler(priceCategoriesController controllers.PriceCateg
 // @Accept  json
 // @Produce  json
 // @Param priceCategory body model.PriceCategories true "Price category data"
-// @Success 200 {object} uuid.UUID
+// @Success 200 {object} myid.UUID
 // @Failure 500 {object} models.KTSErrorMessage
 // @Router /price-categories [put]
 func UpdatePriceCategoryHandler(priceCategoriesController controllers.PriceCategoryControllerI) gin.HandlerFunc {
@@ -124,7 +124,7 @@ func UpdatePriceCategoryHandler(priceCategoriesController controllers.PriceCateg
 // @Router /price-categories/{id} [delete]
 func DeletePriceCategoryHandler(priceCategoriesController controllers.PriceCategoryControllerI) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		priceCategoryId, err := uuid.Parse(c.Param("id"))
+		priceCategoryId, err := myid.Parse(c.Param("id"))
 		if err != nil {
 			utils.HandleErrorAndAbort(c, kts_errors.KTS_BAD_REQUEST)
 			return

--- a/src/handlers/price_category_handler_test.go
+++ b/src/handlers/price_category_handler_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/handlers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/mocks"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/samples"
-	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -32,7 +32,7 @@ func TestUpdatePriceCategoryHandler(t *testing.T) {
 			name: "Success",
 			body: sampleUpdatePriceCategory,
 			setExpectations: func(mockController *mocks.MockPriceCategoryControllerI, priceCategoryData interface{}) {
-				mockController.EXPECT().UpdatePriceCategory(gomock.Any()).Return(sampleUpdatePriceCategory.ID, nil)
+				mockController.EXPECT().UpdatePriceCategory(gomock.Any()).Return(&sampleUpdatePriceCategory.ID, nil)
 			},
 			expectedStatus: http.StatusOK,
 			expectedBody:   sampleUpdatePriceCategory.ID,
@@ -91,7 +91,7 @@ func TestUpdatePriceCategoryHandler(t *testing.T) {
 }
 
 func TestDeletePriceCategoryHandler(t *testing.T) {
-	sampleUpdatePriceCategoryId := utils.NewUUID()
+	sampleUpdatePriceCategoryId := myid.NewUUID()
 
 	testCases := []struct {
 		name            string
@@ -292,7 +292,7 @@ func TestCreatePriceCategoryHandler(t *testing.T) {
 			name: "Success",
 			body: sampleCreatePriceCategory,
 			setExpectations: func(mockController *mocks.MockPriceCategoryControllerI, priceCategoryData interface{}) {
-				mockController.EXPECT().CreatePriceCategory(gomock.Any()).Return(sampleCreatePriceCategory.ID, nil)
+				mockController.EXPECT().CreatePriceCategory(gomock.Any()).Return(&sampleCreatePriceCategory.ID, nil)
 			},
 			expectedStatus: http.StatusCreated,
 			expectedBody:   sampleCreatePriceCategory.ID,

--- a/src/handlers/review_handler.go
+++ b/src/handlers/review_handler.go
@@ -6,9 +6,9 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/controllers"
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 )
 
 // @Summary Create review
@@ -17,7 +17,7 @@ import (
 // @Accept  json
 // @Produce  json
 // @Param review body models.CreateReviewRequest true "Review data"
-// @Success 201 {object} uuid.UUID
+// @Success 201 {object} myid.UUID
 // @Failure 400 {object} models.KTSErrorMessage
 // @Router /reviews [post]
 func CreateReviewHandler(reviewCtrl controllers.ReviewControllerI) gin.HandlerFunc {
@@ -29,13 +29,14 @@ func CreateReviewHandler(reviewCtrl controllers.ReviewControllerI) gin.HandlerFu
 			return
 		}
 
-		userId, ok := c.Request.Context().Value(models.ContextKeyUserID).(*uuid.UUID)
+		usId := c.Request.Context().Value(models.ContextKeyUserID)
+		userId, ok := usId.(myid.UUID)
 		if !ok {
 			utils.HandleErrorAndAbort(c, kts_errors.KTS_UNAUTHORIZED)
 			return
 		}
 
-		review, username, kts_err := reviewCtrl.CreateReview(reviewData, userId)
+		review, username, kts_err := reviewCtrl.CreateReview(reviewData, &userId)
 		if kts_err != nil {
 			utils.HandleErrorAndAbort(c, kts_err)
 			return
@@ -56,13 +57,13 @@ func CreateReviewHandler(reviewCtrl controllers.ReviewControllerI) gin.HandlerFu
 // @Router /reviews/{id} [delete]
 func DeleteReviewHandler(reviewCtrl controllers.ReviewControllerI) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		id, err := uuid.Parse(c.Param("id"))
+		id, err := myid.Parse(c.Param("id"))
 		if err != nil {
 			utils.HandleErrorAndAbort(c, kts_errors.KTS_BAD_REQUEST)
 			return
 		}
 
-		userId, ok := c.Request.Context().Value(models.ContextKeyUserID).(*uuid.UUID)
+		userId, ok := c.Request.Context().Value(models.ContextKeyUserID).(*myid.UUID)
 		if !ok {
 			utils.HandleErrorAndAbort(c, kts_errors.KTS_UNAUTHORIZED)
 			return

--- a/src/handlers/review_handler_test.go
+++ b/src/handlers/review_handler_test.go
@@ -11,6 +11,7 @@ import (
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/mocks"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/samples"
 
 	"github.com/gin-gonic/gin"
@@ -47,7 +48,7 @@ func TestCreateReview(t *testing.T) {
 					IsSpoiler: body["isSpoiler"].(bool),
 					MovieID:   body["movieId"].(string),
 				}
-				mockCtrl.EXPECT().CreateReview(reviewData, user.ID).Return(&review, *user.Username, nil)
+				mockCtrl.EXPECT().CreateReview(reviewData, &user.ID).Return(&review, *user.Username, nil)
 			},
 			expectedBody:   gin.H{"review": review, "username": user.Username},
 			expectedStatus: 201,
@@ -70,7 +71,7 @@ func TestCreateReview(t *testing.T) {
 					IsSpoiler: body["isSpoiler"].(bool),
 					MovieID:   body["movieId"].(string),
 				}
-				mockCtrl.EXPECT().CreateReview(reviewData, user.ID).Return(nil, "", kts_errors.KTS_INTERNAL_ERROR)
+				mockCtrl.EXPECT().CreateReview(reviewData, &user.ID).Return(nil, "", kts_errors.KTS_INTERNAL_ERROR)
 			},
 			expectedBody:   gin.H{"errorMessage": "INTERNAL_ERROR"},
 			expectedStatus: 500,
@@ -139,7 +140,7 @@ func TestDeleteReview(t *testing.T) {
 		name                 string
 		id                   string
 		userId               string
-		setExpectations      func(mockCtrl *mocks.MockReviewControllerI, id uuid.UUID, userId uuid.UUID)
+		setExpectations      func(mockCtrl *mocks.MockReviewControllerI, id myid.UUID, userId myid.UUID)
 		expectedStatus       int
 		expectedResponseBody string
 	}{
@@ -147,7 +148,7 @@ func TestDeleteReview(t *testing.T) {
 			name:   "Success",
 			id:     uuid.NewString(),
 			userId: uuid.NewString(),
-			setExpectations: func(mockCtrl *mocks.MockReviewControllerI, id uuid.UUID, userId uuid.UUID) {
+			setExpectations: func(mockCtrl *mocks.MockReviewControllerI, id myid.UUID, userId myid.UUID) {
 				mockCtrl.EXPECT().DeleteReview(&id, &userId).Return(nil)
 			},
 			expectedStatus:       200,
@@ -157,7 +158,7 @@ func TestDeleteReview(t *testing.T) {
 			name:   "Unauthorized",
 			id:     uuid.NewString(),
 			userId: uuid.NewString(),
-			setExpectations: func(mockCtrl *mocks.MockReviewControllerI, id uuid.UUID, userId uuid.UUID) {
+			setExpectations: func(mockCtrl *mocks.MockReviewControllerI, id myid.UUID, userId myid.UUID) {
 				mockCtrl.EXPECT().DeleteReview(&id, &userId).Return(kts_errors.KTS_FORBIDDEN)
 			},
 			expectedStatus: 403,
@@ -172,7 +173,7 @@ func TestDeleteReview(t *testing.T) {
 			name:   "Internal error",
 			id:     uuid.NewString(),
 			userId: uuid.NewString(),
-			setExpectations: func(mockCtrl *mocks.MockReviewControllerI, id uuid.UUID, userId uuid.UUID) {
+			setExpectations: func(mockCtrl *mocks.MockReviewControllerI, id myid.UUID, userId myid.UUID) {
 				mockCtrl.EXPECT().DeleteReview(&id, &userId).Return(kts_errors.KTS_INTERNAL_ERROR)
 			},
 			expectedStatus: 500,
@@ -186,7 +187,7 @@ func TestDeleteReview(t *testing.T) {
 		{
 			name:            "Invalid id",
 			id:              "invalid id",
-			setExpectations: func(mockCtrl *mocks.MockReviewControllerI, id uuid.UUID, userId uuid.UUID) {},
+			setExpectations: func(mockCtrl *mocks.MockReviewControllerI, id myid.UUID, userId myid.UUID) {},
 			expectedStatus:  400,
 			expectedResponseBody: func() string {
 				expectedResponseBody, _ := json.Marshal(gin.H{
@@ -211,8 +212,8 @@ func TestDeleteReview(t *testing.T) {
 			reviewController := mocks.NewMockReviewControllerI(mockCtrl)
 
 			// create mock request
-			id, _ := uuid.Parse(tc.id)
-			userId, _ := uuid.Parse(tc.userId)
+			id, _ := myid.Parse(tc.id)
+			userId, _ := myid.Parse(tc.userId)
 
 			req := httptest.NewRequest("DELETE", "/reviews/:id", nil)
 			ctx := context.WithValue(req.Context(), models.ContextKeyUserID, &userId)

--- a/src/handlers/theatre_handler.go
+++ b/src/handlers/theatre_handler.go
@@ -6,9 +6,9 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/controllers"
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 )
 
 // @Summary Create theatre
@@ -65,7 +65,7 @@ func CreateCinemaHallHandler(theatreCtrl controllers.TheatreControllerI) gin.Han
 			return
 		}
 
-		kts_err := theatreCtrl.CreateCinemaHall(&cinemaHallData)
+		kts_err := theatreCtrl.CreateCinemaHallFast(&cinemaHallData)
 		if kts_err != nil {
 			utils.HandleErrorAndAbort(c, kts_err)
 			return
@@ -77,7 +77,7 @@ func CreateCinemaHallHandler(theatreCtrl controllers.TheatreControllerI) gin.Han
 
 func GetCinemaHallsForTheatreHandler(theatreCtrl controllers.TheatreControllerI) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		theatreId, err := uuid.Parse(c.Param("theatreId"))
+		theatreId, err := myid.Parse(c.Param("theatreId"))
 		if err != nil {
 			utils.HandleErrorAndAbort(c, kts_errors.KTS_BAD_REQUEST)
 			return

--- a/src/handlers/theatre_handler_test.go
+++ b/src/handlers/theatre_handler_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/handlers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/mocks"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/samples"
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
@@ -180,7 +180,7 @@ func TestCreateCinemaHall(t *testing.T) {
 }
 
 func TestGetCinemaHallsForTheatre(t *testing.T) {
-	theatreId := uuid.New()
+	theatreId := myid.New()
 	sampleCinemaHalls := samples.GetSampleCinemaHalls()
 
 	testCases := []struct {

--- a/src/handlers/ticket_handler.go
+++ b/src/handlers/ticket_handler.go
@@ -6,9 +6,9 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/controllers"
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 )
 
 // @Summary Get Ticket By Id
@@ -22,7 +22,7 @@ import (
 // @Router /tickets/{id} [get]
 func GetTicketByIdHandler(ticketController controllers.TicketControllerI) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		ticketId, err := uuid.Parse(c.Param("ticketId"))
+		ticketId, err := myid.Parse(c.Param("ticketId"))
 		if err != nil {
 			utils.HandleErrorAndAbort(c, kts_errors.KTS_BAD_REQUEST)
 			return
@@ -49,7 +49,7 @@ func GetTicketByIdHandler(ticketController controllers.TicketControllerI) gin.Ha
 // @Router /tickets/{id} [patch]
 func ValidateTicketHandler(ticketController controllers.TicketControllerI) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		ticketId, err := uuid.Parse(c.Param("ticketId"))
+		ticketId, err := myid.Parse(c.Param("ticketId"))
 
 		if err != nil {
 			utils.HandleErrorAndAbort(c, kts_errors.KTS_BAD_REQUEST)

--- a/src/handlers/ticket_handler_test.go
+++ b/src/handlers/ticket_handler_test.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/handlers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/samples"
 
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/mocks"
-	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -41,7 +41,7 @@ func TestGetTicketByIdHandler(t *testing.T) {
 		},
 		{
 			name:          "Internal error",
-			paramTicketId: utils.NewUUID().String(),
+			paramTicketId: myid.NewUUID().String(),
 			setExpectations: func(mockController *mocks.MockTicketControllerI, ticketId string) {
 				mockController.EXPECT().GetTicketById(gomock.Any()).Return(nil, kts_errors.KTS_INTERNAL_ERROR)
 			},
@@ -50,7 +50,7 @@ func TestGetTicketByIdHandler(t *testing.T) {
 		},
 		{
 			name:          "Ticket not found",
-			paramTicketId: utils.NewUUID().String(),
+			paramTicketId: myid.NewUUID().String(),
 			setExpectations: func(mockController *mocks.MockTicketControllerI, ticketId string) {
 				mockController.EXPECT().GetTicketById(gomock.Any()).Return(nil, kts_errors.KTS_NOT_FOUND)
 			},
@@ -59,7 +59,7 @@ func TestGetTicketByIdHandler(t *testing.T) {
 		},
 		{
 			name:          "Ticket found",
-			paramTicketId: utils.NewUUID().String(),
+			paramTicketId: myid.NewUUID().String(),
 			setExpectations: func(mockController *mocks.MockTicketControllerI, ticketId string) {
 				mockController.EXPECT().GetTicketById(gomock.Any()).Return(sampleTicket, nil)
 			},
@@ -107,7 +107,7 @@ func TestValidateTicketHandler(t *testing.T) {
 	}{
 		{
 			name:          "Success",
-			paramTicketId: utils.NewUUID().String(),
+			paramTicketId: myid.NewUUID().String(),
 			setExpectations: func(mockController *mocks.MockTicketControllerI, ticketId string) {
 				mockController.EXPECT().ValidateTicket(gomock.Any()).Return(nil)
 			},
@@ -116,7 +116,7 @@ func TestValidateTicketHandler(t *testing.T) {
 		},
 		{
 			name:          "Internal error",
-			paramTicketId: utils.NewUUID().String(),
+			paramTicketId: myid.NewUUID().String(),
 			setExpectations: func(mockController *mocks.MockTicketControllerI, ticketId string) {
 				mockController.EXPECT().ValidateTicket(gomock.Any()).Return(kts_errors.KTS_INTERNAL_ERROR)
 			},
@@ -125,7 +125,7 @@ func TestValidateTicketHandler(t *testing.T) {
 		},
 		{
 			name:          "Ticket CONFLICT",
-			paramTicketId: utils.NewUUID().String(),
+			paramTicketId: myid.NewUUID().String(),
 			setExpectations: func(mockController *mocks.MockTicketControllerI, ticketId string) {
 				mockController.EXPECT().ValidateTicket(gomock.Any()).Return(kts_errors.KTS_CONFLICT)
 			},

--- a/src/mocks/actor_controller_mock.go
+++ b/src/mocks/actor_controller_mock.go
@@ -12,7 +12,7 @@ import (
 	reflect "reflect"
 
 	models "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	uuid "github.com/google/uuid"
+	myid "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -40,10 +40,10 @@ func (m *MockActorControllerI) EXPECT() *MockActorControllerIMockRecorder {
 }
 
 // CreateActor mocks base method.
-func (m *MockActorControllerI) CreateActor(actor *models.CreateActorDTO) (*uuid.UUID, *models.KTSError) {
+func (m *MockActorControllerI) CreateActor(actor *models.CreateActorDTO) (*myid.UUID, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateActor", actor)
-	ret0, _ := ret[0].(*uuid.UUID)
+	ret0, _ := ret[0].(*myid.UUID)
 	ret1, _ := ret[1].(*models.KTSError)
 	return ret0, ret1
 }
@@ -55,7 +55,7 @@ func (mr *MockActorControllerIMockRecorder) CreateActor(actor any) *gomock.Call 
 }
 
 // GetActorById mocks base method.
-func (m *MockActorControllerI) GetActorById(actorId *uuid.UUID) (*models.ActorDTO, *models.KTSError) {
+func (m *MockActorControllerI) GetActorById(actorId *myid.UUID) (*models.ActorDTO, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetActorById", actorId)
 	ret0, _ := ret[0].(*models.ActorDTO)

--- a/src/mocks/actor_repository_mock.go
+++ b/src/mocks/actor_repository_mock.go
@@ -13,7 +13,7 @@ import (
 
 	model "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	models "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	uuid "github.com/google/uuid"
+	myid "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -41,10 +41,10 @@ func (m *MockActorRepoI) EXPECT() *MockActorRepoIMockRecorder {
 }
 
 // CreateActor mocks base method.
-func (m *MockActorRepoI) CreateActor(actor *model.Actors) (*uuid.UUID, *models.KTSError) {
+func (m *MockActorRepoI) CreateActor(actor *model.Actors) (*myid.UUID, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateActor", actor)
-	ret0, _ := ret[0].(*uuid.UUID)
+	ret0, _ := ret[0].(*myid.UUID)
 	ret1, _ := ret[1].(*models.KTSError)
 	return ret0, ret1
 }
@@ -56,10 +56,10 @@ func (mr *MockActorRepoIMockRecorder) CreateActor(actor any) *gomock.Call {
 }
 
 // CreateActorPicture mocks base method.
-func (m *MockActorRepoI) CreateActorPicture(actorPicture *model.ActorPictures) (*uuid.UUID, *models.KTSError) {
+func (m *MockActorRepoI) CreateActorPicture(actorPicture *model.ActorPictures) (*myid.UUID, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateActorPicture", actorPicture)
-	ret0, _ := ret[0].(*uuid.UUID)
+	ret0, _ := ret[0].(*myid.UUID)
 	ret1, _ := ret[1].(*models.KTSError)
 	return ret0, ret1
 }
@@ -71,7 +71,7 @@ func (mr *MockActorRepoIMockRecorder) CreateActorPicture(actorPicture any) *gomo
 }
 
 // GetActorById mocks base method.
-func (m *MockActorRepoI) GetActorById(actorId *uuid.UUID) (*models.ActorDTO, *models.KTSError) {
+func (m *MockActorRepoI) GetActorById(actorId *myid.UUID) (*models.ActorDTO, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetActorById", actorId)
 	ret0, _ := ret[0].(*models.ActorDTO)

--- a/src/mocks/event_controller_mock.go
+++ b/src/mocks/event_controller_mock.go
@@ -13,7 +13,7 @@ import (
 
 	model "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	models "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	uuid "github.com/google/uuid"
+	myid "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -41,10 +41,10 @@ func (m *MockEventControllerI) EXPECT() *MockEventControllerIMockRecorder {
 }
 
 // CreateEvent mocks base method.
-func (m *MockEventControllerI) CreateEvent(event *models.CreateEvtDTO) (*uuid.UUID, *models.KTSError) {
+func (m *MockEventControllerI) CreateEvent(event *models.CreateEvtDTO) (*myid.UUID, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateEvent", event)
-	ret0, _ := ret[0].(*uuid.UUID)
+	ret0, _ := ret[0].(*myid.UUID)
 	ret1, _ := ret[1].(*models.KTSError)
 	return ret0, ret1
 }
@@ -56,7 +56,7 @@ func (mr *MockEventControllerIMockRecorder) CreateEvent(event any) *gomock.Call 
 }
 
 // GetEventById mocks base method.
-func (m *MockEventControllerI) GetEventById(eventId *uuid.UUID) (*models.GetSpecialEventsDTO, *models.KTSError) {
+func (m *MockEventControllerI) GetEventById(eventId *myid.UUID) (*models.GetSpecialEventsDTO, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEventById", eventId)
 	ret0, _ := ret[0].(*models.GetSpecialEventsDTO)
@@ -71,7 +71,7 @@ func (mr *MockEventControllerIMockRecorder) GetEventById(eventId any) *gomock.Ca
 }
 
 // GetEventsForMovie mocks base method.
-func (m *MockEventControllerI) GetEventsForMovie(movieId, theatreId *uuid.UUID) ([]*model.Events, *models.KTSError) {
+func (m *MockEventControllerI) GetEventsForMovie(movieId, theatreId *myid.UUID) ([]*model.Events, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEventsForMovie", movieId, theatreId)
 	ret0, _ := ret[0].([]*model.Events)

--- a/src/mocks/event_repository_mock.go
+++ b/src/mocks/event_repository_mock.go
@@ -13,7 +13,7 @@ import (
 
 	model "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	models "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	uuid "github.com/google/uuid"
+	myid "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -41,7 +41,7 @@ func (m *MockEventRepo) EXPECT() *MockEventRepoMockRecorder {
 }
 
 // AddEventMovie mocks base method.
-func (m *MockEventRepo) AddEventMovie(eventId, movieId *uuid.UUID) *models.KTSError {
+func (m *MockEventRepo) AddEventMovie(eventId, movieId *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddEventMovie", eventId, movieId)
 	ret0, _ := ret[0].(*models.KTSError)
@@ -55,10 +55,10 @@ func (mr *MockEventRepoMockRecorder) AddEventMovie(eventId, movieId any) *gomock
 }
 
 // CreateEvent mocks base method.
-func (m *MockEventRepo) CreateEvent(event *model.Events) (*uuid.UUID, *models.KTSError) {
+func (m *MockEventRepo) CreateEvent(event *model.Events) (*myid.UUID, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateEvent", event)
-	ret0, _ := ret[0].(*uuid.UUID)
+	ret0, _ := ret[0].(*myid.UUID)
 	ret1, _ := ret[1].(*models.KTSError)
 	return ret0, ret1
 }
@@ -97,8 +97,22 @@ func (mr *MockEventRepoMockRecorder) CreateEventSeatCategory(eventSeatCategory a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEventSeatCategory", reflect.TypeOf((*MockEventRepo)(nil).CreateEventSeatCategory), eventSeatCategory)
 }
 
+// CreateEventSeats mocks base method.
+func (m *MockEventRepo) CreateEventSeats(eventSeats []*model.EventSeats) *models.KTSError {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateEventSeats", eventSeats)
+	ret0, _ := ret[0].(*models.KTSError)
+	return ret0
+}
+
+// CreateEventSeats indicates an expected call of CreateEventSeats.
+func (mr *MockEventRepoMockRecorder) CreateEventSeats(eventSeats any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEventSeats", reflect.TypeOf((*MockEventRepo)(nil).CreateEventSeats), eventSeats)
+}
+
 // GetEventById mocks base method.
-func (m *MockEventRepo) GetEventById(eventId *uuid.UUID) (*models.GetSpecialEventsDTO, *models.KTSError) {
+func (m *MockEventRepo) GetEventById(eventId *myid.UUID) (*models.GetSpecialEventsDTO, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEventById", eventId)
 	ret0, _ := ret[0].(*models.GetSpecialEventsDTO)
@@ -113,7 +127,7 @@ func (mr *MockEventRepoMockRecorder) GetEventById(eventId any) *gomock.Call {
 }
 
 // GetEventsForMovie mocks base method.
-func (m *MockEventRepo) GetEventsForMovie(movieId, theatreId *uuid.UUID) ([]*model.Events, *models.KTSError) {
+func (m *MockEventRepo) GetEventsForMovie(movieId, theatreId *myid.UUID) ([]*model.Events, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEventsForMovie", movieId, theatreId)
 	ret0, _ := ret[0].([]*model.Events)

--- a/src/mocks/eventseat_repository_mock.go
+++ b/src/mocks/eventseat_repository_mock.go
@@ -14,7 +14,7 @@ import (
 
 	model "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	models "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	uuid "github.com/google/uuid"
+	myid "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -42,7 +42,7 @@ func (m *MockEventSeatRepoI) EXPECT() *MockEventSeatRepoIMockRecorder {
 }
 
 // BlockEventSeatIfAvailable mocks base method.
-func (m *MockEventSeatRepoI) BlockEventSeatIfAvailable(eventId, seatId, userId *uuid.UUID, blockedUntil *time.Time) *models.KTSError {
+func (m *MockEventSeatRepoI) BlockEventSeatIfAvailable(eventId, seatId, userId *myid.UUID, blockedUntil *time.Time) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BlockEventSeatIfAvailable", eventId, seatId, userId, blockedUntil)
 	ret0, _ := ret[0].(*models.KTSError)
@@ -56,7 +56,7 @@ func (mr *MockEventSeatRepoIMockRecorder) BlockEventSeatIfAvailable(eventId, sea
 }
 
 // GetEventSeats mocks base method.
-func (m *MockEventSeatRepoI) GetEventSeats(eventId *uuid.UUID) (*[]models.GetEventSeatsDTO, *models.KTSError) {
+func (m *MockEventSeatRepoI) GetEventSeats(eventId *myid.UUID) (*[]models.GetEventSeatsDTO, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEventSeats", eventId)
 	ret0, _ := ret[0].(*[]models.GetEventSeatsDTO)
@@ -71,7 +71,7 @@ func (mr *MockEventSeatRepoIMockRecorder) GetEventSeats(eventId any) *gomock.Cal
 }
 
 // GetSelectedSeats mocks base method.
-func (m *MockEventSeatRepoI) GetSelectedSeats(eventId, userId *uuid.UUID) (*[]models.GetSlectedSeatsDTO, *models.KTSError) {
+func (m *MockEventSeatRepoI) GetSelectedSeats(eventId, userId *myid.UUID) (*[]models.GetSlectedSeatsDTO, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSelectedSeats", eventId, userId)
 	ret0, _ := ret[0].(*[]models.GetSlectedSeatsDTO)
@@ -86,7 +86,7 @@ func (mr *MockEventSeatRepoIMockRecorder) GetSelectedSeats(eventId, userId any) 
 }
 
 // UnblockAllEventSeats mocks base method.
-func (m *MockEventSeatRepoI) UnblockAllEventSeats(eventId, userId *uuid.UUID) *models.KTSError {
+func (m *MockEventSeatRepoI) UnblockAllEventSeats(eventId, userId *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnblockAllEventSeats", eventId, userId)
 	ret0, _ := ret[0].(*models.KTSError)
@@ -100,7 +100,7 @@ func (mr *MockEventSeatRepoIMockRecorder) UnblockAllEventSeats(eventId, userId a
 }
 
 // UnblockEventSeat mocks base method.
-func (m *MockEventSeatRepoI) UnblockEventSeat(eventId, seatId, userId *uuid.UUID) *models.KTSError {
+func (m *MockEventSeatRepoI) UnblockEventSeat(eventId, seatId, userId *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnblockEventSeat", eventId, seatId, userId)
 	ret0, _ := ret[0].(*models.KTSError)
@@ -114,7 +114,7 @@ func (mr *MockEventSeatRepoIMockRecorder) UnblockEventSeat(eventId, seatId, user
 }
 
 // UpdateBlockedUntilTimeForUserEventSeats mocks base method.
-func (m *MockEventSeatRepoI) UpdateBlockedUntilTimeForUserEventSeats(eventId, userId *uuid.UUID, blockedUntil *time.Time) (int64, *models.KTSError) {
+func (m *MockEventSeatRepoI) UpdateBlockedUntilTimeForUserEventSeats(eventId, userId *myid.UUID, blockedUntil *time.Time) (int64, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateBlockedUntilTimeForUserEventSeats", eventId, userId, blockedUntil)
 	ret0, _ := ret[0].(int64)

--- a/src/mocks/eventseats_controller_mock.go
+++ b/src/mocks/eventseats_controller_mock.go
@@ -13,7 +13,7 @@ import (
 	time "time"
 
 	models "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	uuid "github.com/google/uuid"
+	myid "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -41,7 +41,7 @@ func (m *MockEventSeatControllerI) EXPECT() *MockEventSeatControllerIMockRecorde
 }
 
 // AreUserSeatsNextToEachOther mocks base method.
-func (m *MockEventSeatControllerI) AreUserSeatsNextToEachOther(eventId, userId, eventSeatId *uuid.UUID) (bool, *models.KTSError) {
+func (m *MockEventSeatControllerI) AreUserSeatsNextToEachOther(eventId, userId, eventSeatId *myid.UUID) (bool, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AreUserSeatsNextToEachOther", eventId, userId, eventSeatId)
 	ret0, _ := ret[0].(bool)
@@ -56,7 +56,7 @@ func (mr *MockEventSeatControllerIMockRecorder) AreUserSeatsNextToEachOther(even
 }
 
 // BlockEventSeat mocks base method.
-func (m *MockEventSeatControllerI) BlockEventSeat(eventId, eventSeatId, userId *uuid.UUID) (*time.Time, *models.KTSError) {
+func (m *MockEventSeatControllerI) BlockEventSeat(eventId, eventSeatId, userId *myid.UUID) (*time.Time, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BlockEventSeat", eventId, eventSeatId, userId)
 	ret0, _ := ret[0].(*time.Time)
@@ -71,7 +71,7 @@ func (mr *MockEventSeatControllerIMockRecorder) BlockEventSeat(eventId, eventSea
 }
 
 // GetEventSeats mocks base method.
-func (m *MockEventSeatControllerI) GetEventSeats(eventId, userId *uuid.UUID) (*[][]models.GetSeatsForSeatSelectorDTO, *[]models.GetSeatsForSeatSelectorDTO, *time.Time, *models.KTSError) {
+func (m *MockEventSeatControllerI) GetEventSeats(eventId, userId *myid.UUID) (*[][]models.GetSeatsForSeatSelectorDTO, *[]models.GetSeatsForSeatSelectorDTO, *time.Time, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEventSeats", eventId, userId)
 	ret0, _ := ret[0].(*[][]models.GetSeatsForSeatSelectorDTO)
@@ -88,7 +88,7 @@ func (mr *MockEventSeatControllerIMockRecorder) GetEventSeats(eventId, userId an
 }
 
 // GetSelectedSeats mocks base method.
-func (m *MockEventSeatControllerI) GetSelectedSeats(eventId, userId *uuid.UUID) (*[]models.GetSlectedSeatsDTO, *models.KTSError) {
+func (m *MockEventSeatControllerI) GetSelectedSeats(eventId, userId *myid.UUID) (*[]models.GetSlectedSeatsDTO, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSelectedSeats", eventId, userId)
 	ret0, _ := ret[0].(*[]models.GetSlectedSeatsDTO)
@@ -103,7 +103,7 @@ func (mr *MockEventSeatControllerIMockRecorder) GetSelectedSeats(eventId, userId
 }
 
 // UnblockAllEventSeats mocks base method.
-func (m *MockEventSeatControllerI) UnblockAllEventSeats(eventId, userId *uuid.UUID) *models.KTSError {
+func (m *MockEventSeatControllerI) UnblockAllEventSeats(eventId, userId *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnblockAllEventSeats", eventId, userId)
 	ret0, _ := ret[0].(*models.KTSError)
@@ -117,7 +117,7 @@ func (mr *MockEventSeatControllerIMockRecorder) UnblockAllEventSeats(eventId, us
 }
 
 // UnblockEventSeat mocks base method.
-func (m *MockEventSeatControllerI) UnblockEventSeat(eventId, eventSeatId, userId *uuid.UUID) (*time.Time, *models.KTSError) {
+func (m *MockEventSeatControllerI) UnblockEventSeat(eventId, eventSeatId, userId *myid.UUID) (*time.Time, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnblockEventSeat", eventId, eventSeatId, userId)
 	ret0, _ := ret[0].(*time.Time)

--- a/src/mocks/genre_controller_mock.go
+++ b/src/mocks/genre_controller_mock.go
@@ -13,7 +13,7 @@ import (
 
 	model "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	models "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	uuid "github.com/google/uuid"
+	myid "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -41,10 +41,10 @@ func (m *MockGenreControllerI) EXPECT() *MockGenreControllerIMockRecorder {
 }
 
 // CreateGenre mocks base method.
-func (m *MockGenreControllerI) CreateGenre(name *string) (*uuid.UUID, *models.KTSError) {
+func (m *MockGenreControllerI) CreateGenre(name *string) (*myid.UUID, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateGenre", name)
-	ret0, _ := ret[0].(*uuid.UUID)
+	ret0, _ := ret[0].(*myid.UUID)
 	ret1, _ := ret[1].(*models.KTSError)
 	return ret0, ret1
 }
@@ -56,7 +56,7 @@ func (mr *MockGenreControllerIMockRecorder) CreateGenre(name any) *gomock.Call {
 }
 
 // DeleteGenre mocks base method.
-func (m *MockGenreControllerI) DeleteGenre(genre_id *uuid.UUID) *models.KTSError {
+func (m *MockGenreControllerI) DeleteGenre(genre_id *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteGenre", genre_id)
 	ret0, _ := ret[0].(*models.KTSError)

--- a/src/mocks/genre_repository_mock.go
+++ b/src/mocks/genre_repository_mock.go
@@ -13,7 +13,7 @@ import (
 
 	model "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	models "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	uuid "github.com/google/uuid"
+	myid "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -41,10 +41,10 @@ func (m *MockGenreRepositoryI) EXPECT() *MockGenreRepositoryIMockRecorder {
 }
 
 // CreateGenre mocks base method.
-func (m *MockGenreRepositoryI) CreateGenre(name *string) (*uuid.UUID, *models.KTSError) {
+func (m *MockGenreRepositoryI) CreateGenre(name *string) (*myid.UUID, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateGenre", name)
-	ret0, _ := ret[0].(*uuid.UUID)
+	ret0, _ := ret[0].(*myid.UUID)
 	ret1, _ := ret[1].(*models.KTSError)
 	return ret0, ret1
 }
@@ -56,7 +56,7 @@ func (mr *MockGenreRepositoryIMockRecorder) CreateGenre(name any) *gomock.Call {
 }
 
 // DeleteGenre mocks base method.
-func (m *MockGenreRepositoryI) DeleteGenre(genreId *uuid.UUID) *models.KTSError {
+func (m *MockGenreRepositoryI) DeleteGenre(genreId *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteGenre", genreId)
 	ret0, _ := ret[0].(*models.KTSError)

--- a/src/mocks/movie_actor_repository_mock.go
+++ b/src/mocks/movie_actor_repository_mock.go
@@ -12,7 +12,7 @@ import (
 	reflect "reflect"
 
 	models "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	uuid "github.com/google/uuid"
+	myid "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -40,7 +40,7 @@ func (m *MockMovieActorRepositoryI) EXPECT() *MockMovieActorRepositoryIMockRecor
 }
 
 // AddMovieActor mocks base method.
-func (m *MockMovieActorRepositoryI) AddMovieActor(movieId, actorId *uuid.UUID) *models.KTSError {
+func (m *MockMovieActorRepositoryI) AddMovieActor(movieId, actorId *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddMovieActor", movieId, actorId)
 	ret0, _ := ret[0].(*models.KTSError)
@@ -54,7 +54,7 @@ func (mr *MockMovieActorRepositoryIMockRecorder) AddMovieActor(movieId, actorId 
 }
 
 // RemoveAllActorCombinationWithMovie mocks base method.
-func (m *MockMovieActorRepositoryI) RemoveAllActorCombinationWithMovie(movieId *uuid.UUID) *models.KTSError {
+func (m *MockMovieActorRepositoryI) RemoveAllActorCombinationWithMovie(movieId *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveAllActorCombinationWithMovie", movieId)
 	ret0, _ := ret[0].(*models.KTSError)
@@ -68,7 +68,7 @@ func (mr *MockMovieActorRepositoryIMockRecorder) RemoveAllActorCombinationWithMo
 }
 
 // RemoveMovieActor mocks base method.
-func (m *MockMovieActorRepositoryI) RemoveMovieActor(movieId, actorId *uuid.UUID) *models.KTSError {
+func (m *MockMovieActorRepositoryI) RemoveMovieActor(movieId, actorId *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveMovieActor", movieId, actorId)
 	ret0, _ := ret[0].(*models.KTSError)

--- a/src/mocks/movie_controller_mock.go
+++ b/src/mocks/movie_controller_mock.go
@@ -13,7 +13,7 @@ import (
 
 	model "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	models "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	uuid "github.com/google/uuid"
+	myid "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -41,10 +41,10 @@ func (m *MockMovieControllerI) EXPECT() *MockMovieControllerIMockRecorder {
 }
 
 // CreateMovie mocks base method.
-func (m *MockMovieControllerI) CreateMovie(movie *models.MovieDTOCreate) (*uuid.UUID, *models.KTSError) {
+func (m *MockMovieControllerI) CreateMovie(movie *models.MovieDTOCreate) (*myid.UUID, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateMovie", movie)
-	ret0, _ := ret[0].(*uuid.UUID)
+	ret0, _ := ret[0].(*myid.UUID)
 	ret1, _ := ret[1].(*models.KTSError)
 	return ret0, ret1
 }
@@ -56,7 +56,7 @@ func (mr *MockMovieControllerIMockRecorder) CreateMovie(movie any) *gomock.Call 
 }
 
 // DeleteMovie mocks base method.
-func (m *MockMovieControllerI) DeleteMovie(movieId *uuid.UUID) *models.KTSError {
+func (m *MockMovieControllerI) DeleteMovie(movieId *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteMovie", movieId)
 	ret0, _ := ret[0].(*models.KTSError)
@@ -70,7 +70,7 @@ func (mr *MockMovieControllerIMockRecorder) DeleteMovie(movieId any) *gomock.Cal
 }
 
 // GetMovieById mocks base method.
-func (m *MockMovieControllerI) GetMovieById(movieId *uuid.UUID) (*models.MovieWithEverything, *models.KTSError) {
+func (m *MockMovieControllerI) GetMovieById(movieId *myid.UUID) (*models.MovieWithEverything, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMovieById", movieId)
 	ret0, _ := ret[0].(*models.MovieWithEverything)

--- a/src/mocks/movie_genres_repository_mock.go
+++ b/src/mocks/movie_genres_repository_mock.go
@@ -12,7 +12,7 @@ import (
 	reflect "reflect"
 
 	models "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	uuid "github.com/google/uuid"
+	myid "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -40,7 +40,7 @@ func (m *MockMovieGenreRepositoryI) EXPECT() *MockMovieGenreRepositoryIMockRecor
 }
 
 // AddMovieGenre mocks base method.
-func (m *MockMovieGenreRepositoryI) AddMovieGenre(movieId, genreId *uuid.UUID) *models.KTSError {
+func (m *MockMovieGenreRepositoryI) AddMovieGenre(movieId, genreId *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddMovieGenre", movieId, genreId)
 	ret0, _ := ret[0].(*models.KTSError)
@@ -54,7 +54,7 @@ func (mr *MockMovieGenreRepositoryIMockRecorder) AddMovieGenre(movieId, genreId 
 }
 
 // RemoveAllGenreCombinationWithMovie mocks base method.
-func (m *MockMovieGenreRepositoryI) RemoveAllGenreCombinationWithMovie(movieId *uuid.UUID) *models.KTSError {
+func (m *MockMovieGenreRepositoryI) RemoveAllGenreCombinationWithMovie(movieId *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveAllGenreCombinationWithMovie", movieId)
 	ret0, _ := ret[0].(*models.KTSError)
@@ -68,7 +68,7 @@ func (mr *MockMovieGenreRepositoryIMockRecorder) RemoveAllGenreCombinationWithMo
 }
 
 // RemoveAllMovieCombinationWithGenre mocks base method.
-func (m *MockMovieGenreRepositoryI) RemoveAllMovieCombinationWithGenre(genreId *uuid.UUID) *models.KTSError {
+func (m *MockMovieGenreRepositoryI) RemoveAllMovieCombinationWithGenre(genreId *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveAllMovieCombinationWithGenre", genreId)
 	ret0, _ := ret[0].(*models.KTSError)
@@ -82,7 +82,7 @@ func (mr *MockMovieGenreRepositoryIMockRecorder) RemoveAllMovieCombinationWithGe
 }
 
 // RemoveMovieGenre mocks base method.
-func (m *MockMovieGenreRepositoryI) RemoveMovieGenre(movieId, genreId *uuid.UUID) *models.KTSError {
+func (m *MockMovieGenreRepositoryI) RemoveMovieGenre(movieId, genreId *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveMovieGenre", movieId, genreId)
 	ret0, _ := ret[0].(*models.KTSError)

--- a/src/mocks/movie_producer_repository_mock.go
+++ b/src/mocks/movie_producer_repository_mock.go
@@ -12,7 +12,7 @@ import (
 	reflect "reflect"
 
 	models "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	uuid "github.com/google/uuid"
+	myid "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -40,7 +40,7 @@ func (m *MockMovieProducerRepositoryI) EXPECT() *MockMovieProducerRepositoryIMoc
 }
 
 // AddMovieProducer mocks base method.
-func (m *MockMovieProducerRepositoryI) AddMovieProducer(movieId, producerId *uuid.UUID) *models.KTSError {
+func (m *MockMovieProducerRepositoryI) AddMovieProducer(movieId, producerId *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddMovieProducer", movieId, producerId)
 	ret0, _ := ret[0].(*models.KTSError)
@@ -54,7 +54,7 @@ func (mr *MockMovieProducerRepositoryIMockRecorder) AddMovieProducer(movieId, pr
 }
 
 // RemoveAllProducerCombinationWithMovie mocks base method.
-func (m *MockMovieProducerRepositoryI) RemoveAllProducerCombinationWithMovie(movieId *uuid.UUID) *models.KTSError {
+func (m *MockMovieProducerRepositoryI) RemoveAllProducerCombinationWithMovie(movieId *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveAllProducerCombinationWithMovie", movieId)
 	ret0, _ := ret[0].(*models.KTSError)
@@ -68,7 +68,7 @@ func (mr *MockMovieProducerRepositoryIMockRecorder) RemoveAllProducerCombination
 }
 
 // RemoveMovieProducer mocks base method.
-func (m *MockMovieProducerRepositoryI) RemoveMovieProducer(movieId, producerId *uuid.UUID) *models.KTSError {
+func (m *MockMovieProducerRepositoryI) RemoveMovieProducer(movieId, producerId *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveMovieProducer", movieId, producerId)
 	ret0, _ := ret[0].(*models.KTSError)

--- a/src/mocks/movie_repository_mock.go
+++ b/src/mocks/movie_repository_mock.go
@@ -13,7 +13,7 @@ import (
 
 	model "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	models "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	uuid "github.com/google/uuid"
+	myid "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -41,10 +41,10 @@ func (m *MockMovieRepositoryI) EXPECT() *MockMovieRepositoryIMockRecorder {
 }
 
 // CreateMovie mocks base method.
-func (m *MockMovieRepositoryI) CreateMovie(movie *model.Movies) (*uuid.UUID, *models.KTSError) {
+func (m *MockMovieRepositoryI) CreateMovie(movie *model.Movies) (*myid.UUID, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateMovie", movie)
-	ret0, _ := ret[0].(*uuid.UUID)
+	ret0, _ := ret[0].(*myid.UUID)
 	ret1, _ := ret[1].(*models.KTSError)
 	return ret0, ret1
 }
@@ -56,7 +56,7 @@ func (mr *MockMovieRepositoryIMockRecorder) CreateMovie(movie any) *gomock.Call 
 }
 
 // DeleteMovie mocks base method.
-func (m *MockMovieRepositoryI) DeleteMovie(movieId *uuid.UUID) *models.KTSError {
+func (m *MockMovieRepositoryI) DeleteMovie(movieId *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteMovie", movieId)
 	ret0, _ := ret[0].(*models.KTSError)
@@ -70,7 +70,7 @@ func (mr *MockMovieRepositoryIMockRecorder) DeleteMovie(movieId any) *gomock.Cal
 }
 
 // GetMovieById mocks base method.
-func (m *MockMovieRepositoryI) GetMovieById(movieId *uuid.UUID) (*models.MovieWithEverything, *models.KTSError) {
+func (m *MockMovieRepositoryI) GetMovieById(movieId *myid.UUID) (*models.MovieWithEverything, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMovieById", movieId)
 	ret0, _ := ret[0].(*models.MovieWithEverything)

--- a/src/mocks/order_controller_mock.go
+++ b/src/mocks/order_controller_mock.go
@@ -12,7 +12,7 @@ import (
 	reflect "reflect"
 
 	models "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	uuid "github.com/google/uuid"
+	myid "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -40,10 +40,10 @@ func (m *MockOrderControllerI) EXPECT() *MockOrderControllerIMockRecorder {
 }
 
 // CreateOrder mocks base method.
-func (m *MockOrderControllerI) CreateOrder(createOrderDTO models.CreateOrderDTO, eventId, userId *uuid.UUID, isReservation bool) (*uuid.UUID, *models.KTSError) {
+func (m *MockOrderControllerI) CreateOrder(createOrderDTO models.CreateOrderDTO, eventId, userId *myid.UUID, isReservation bool) (*myid.UUID, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateOrder", createOrderDTO, eventId, userId, isReservation)
-	ret0, _ := ret[0].(*uuid.UUID)
+	ret0, _ := ret[0].(*myid.UUID)
 	ret1, _ := ret[1].(*models.KTSError)
 	return ret0, ret1
 }
@@ -55,7 +55,7 @@ func (mr *MockOrderControllerIMockRecorder) CreateOrder(createOrderDTO, eventId,
 }
 
 // GetOrderById mocks base method.
-func (m *MockOrderControllerI) GetOrderById(orderId, userId *uuid.UUID) (*models.GetOrderDTO, *models.KTSError) {
+func (m *MockOrderControllerI) GetOrderById(orderId, userId *myid.UUID) (*models.GetOrderDTO, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOrderById", orderId, userId)
 	ret0, _ := ret[0].(*models.GetOrderDTO)
@@ -70,7 +70,7 @@ func (mr *MockOrderControllerIMockRecorder) GetOrderById(orderId, userId any) *g
 }
 
 // GetOrders mocks base method.
-func (m *MockOrderControllerI) GetOrders(userId *uuid.UUID) (*[]models.GetOrderDTO, *models.KTSError) {
+func (m *MockOrderControllerI) GetOrders(userId *myid.UUID) (*[]models.GetOrderDTO, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOrders", userId)
 	ret0, _ := ret[0].(*[]models.GetOrderDTO)

--- a/src/mocks/order_repository_mock.go
+++ b/src/mocks/order_repository_mock.go
@@ -13,7 +13,7 @@ import (
 
 	model "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	models "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	uuid "github.com/google/uuid"
+	myid "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -41,10 +41,10 @@ func (m *MockOrderRepoI) EXPECT() *MockOrderRepoIMockRecorder {
 }
 
 // CreateOrder mocks base method.
-func (m *MockOrderRepoI) CreateOrder(order *model.Orders) (*uuid.UUID, *models.KTSError) {
+func (m *MockOrderRepoI) CreateOrder(order *model.Orders) (*myid.UUID, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateOrder", order)
-	ret0, _ := ret[0].(*uuid.UUID)
+	ret0, _ := ret[0].(*myid.UUID)
 	ret1, _ := ret[1].(*models.KTSError)
 	return ret0, ret1
 }
@@ -56,7 +56,7 @@ func (mr *MockOrderRepoIMockRecorder) CreateOrder(order any) *gomock.Call {
 }
 
 // GetOrderById mocks base method.
-func (m *MockOrderRepoI) GetOrderById(orderId, userId *uuid.UUID) (*models.GetOrderDTO, *models.KTSError) {
+func (m *MockOrderRepoI) GetOrderById(orderId, userId *myid.UUID) (*models.GetOrderDTO, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOrderById", orderId, userId)
 	ret0, _ := ret[0].(*models.GetOrderDTO)
@@ -71,7 +71,7 @@ func (mr *MockOrderRepoIMockRecorder) GetOrderById(orderId, userId any) *gomock.
 }
 
 // GetOrders mocks base method.
-func (m *MockOrderRepoI) GetOrders(userId *uuid.UUID) (*[]models.GetOrderDTO, *models.KTSError) {
+func (m *MockOrderRepoI) GetOrders(userId *myid.UUID) (*[]models.GetOrderDTO, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOrders", userId)
 	ret0, _ := ret[0].(*[]models.GetOrderDTO)

--- a/src/mocks/price_category_controller_mock.go
+++ b/src/mocks/price_category_controller_mock.go
@@ -13,7 +13,7 @@ import (
 
 	model "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	models "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	uuid "github.com/google/uuid"
+	myid "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -41,10 +41,10 @@ func (m *MockPriceCategoryControllerI) EXPECT() *MockPriceCategoryControllerIMoc
 }
 
 // CreatePriceCategory mocks base method.
-func (m *MockPriceCategoryControllerI) CreatePriceCategory(priceCategory *model.PriceCategories) (*uuid.UUID, *models.KTSError) {
+func (m *MockPriceCategoryControllerI) CreatePriceCategory(priceCategory *model.PriceCategories) (*myid.UUID, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePriceCategory", priceCategory)
-	ret0, _ := ret[0].(*uuid.UUID)
+	ret0, _ := ret[0].(*myid.UUID)
 	ret1, _ := ret[1].(*models.KTSError)
 	return ret0, ret1
 }
@@ -56,7 +56,7 @@ func (mr *MockPriceCategoryControllerIMockRecorder) CreatePriceCategory(priceCat
 }
 
 // DeletePriceCategory mocks base method.
-func (m *MockPriceCategoryControllerI) DeletePriceCategory(id *uuid.UUID) *models.KTSError {
+func (m *MockPriceCategoryControllerI) DeletePriceCategory(id *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeletePriceCategory", id)
 	ret0, _ := ret[0].(*models.KTSError)
@@ -85,7 +85,7 @@ func (mr *MockPriceCategoryControllerIMockRecorder) GetPriceCategories() *gomock
 }
 
 // GetPriceCategoryById mocks base method.
-func (m *MockPriceCategoryControllerI) GetPriceCategoryById(id *uuid.UUID) (*model.PriceCategories, *models.KTSError) {
+func (m *MockPriceCategoryControllerI) GetPriceCategoryById(id *myid.UUID) (*model.PriceCategories, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPriceCategoryById", id)
 	ret0, _ := ret[0].(*model.PriceCategories)
@@ -100,10 +100,10 @@ func (mr *MockPriceCategoryControllerIMockRecorder) GetPriceCategoryById(id any)
 }
 
 // UpdatePriceCategory mocks base method.
-func (m *MockPriceCategoryControllerI) UpdatePriceCategory(priceCategory *model.PriceCategories) (*uuid.UUID, *models.KTSError) {
+func (m *MockPriceCategoryControllerI) UpdatePriceCategory(priceCategory *model.PriceCategories) (*myid.UUID, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdatePriceCategory", priceCategory)
-	ret0, _ := ret[0].(*uuid.UUID)
+	ret0, _ := ret[0].(*myid.UUID)
 	ret1, _ := ret[1].(*models.KTSError)
 	return ret0, ret1
 }

--- a/src/mocks/price_category_repository_mock.go
+++ b/src/mocks/price_category_repository_mock.go
@@ -13,7 +13,7 @@ import (
 
 	model "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	models "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	uuid "github.com/google/uuid"
+	myid "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -41,10 +41,10 @@ func (m *MockPriceCategoryRepositoryI) EXPECT() *MockPriceCategoryRepositoryIMoc
 }
 
 // CreatePriceCategory mocks base method.
-func (m *MockPriceCategoryRepositoryI) CreatePriceCategory(priceCategory *model.PriceCategories) (*uuid.UUID, *models.KTSError) {
+func (m *MockPriceCategoryRepositoryI) CreatePriceCategory(priceCategory *model.PriceCategories) (*myid.UUID, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePriceCategory", priceCategory)
-	ret0, _ := ret[0].(*uuid.UUID)
+	ret0, _ := ret[0].(*myid.UUID)
 	ret1, _ := ret[1].(*models.KTSError)
 	return ret0, ret1
 }
@@ -56,7 +56,7 @@ func (mr *MockPriceCategoryRepositoryIMockRecorder) CreatePriceCategory(priceCat
 }
 
 // DeletePriceCategory mocks base method.
-func (m *MockPriceCategoryRepositoryI) DeletePriceCategory(id *uuid.UUID) *models.KTSError {
+func (m *MockPriceCategoryRepositoryI) DeletePriceCategory(id *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeletePriceCategory", id)
 	ret0, _ := ret[0].(*models.KTSError)
@@ -85,7 +85,7 @@ func (mr *MockPriceCategoryRepositoryIMockRecorder) GetPriceCategories() *gomock
 }
 
 // GetPriceCategoryById mocks base method.
-func (m *MockPriceCategoryRepositoryI) GetPriceCategoryById(id *uuid.UUID) (*model.PriceCategories, *models.KTSError) {
+func (m *MockPriceCategoryRepositoryI) GetPriceCategoryById(id *myid.UUID) (*model.PriceCategories, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPriceCategoryById", id)
 	ret0, _ := ret[0].(*model.PriceCategories)
@@ -100,10 +100,10 @@ func (mr *MockPriceCategoryRepositoryIMockRecorder) GetPriceCategoryById(id any)
 }
 
 // UpdatePriceCategory mocks base method.
-func (m *MockPriceCategoryRepositoryI) UpdatePriceCategory(priceCategory *model.PriceCategories) (*uuid.UUID, *models.KTSError) {
+func (m *MockPriceCategoryRepositoryI) UpdatePriceCategory(priceCategory *model.PriceCategories) (*myid.UUID, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdatePriceCategory", priceCategory)
-	ret0, _ := ret[0].(*uuid.UUID)
+	ret0, _ := ret[0].(*myid.UUID)
 	ret1, _ := ret[1].(*models.KTSError)
 	return ret0, ret1
 }

--- a/src/mocks/review_controller_mock.go
+++ b/src/mocks/review_controller_mock.go
@@ -13,7 +13,7 @@ import (
 
 	model "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	models "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	uuid "github.com/google/uuid"
+	myid "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -41,7 +41,7 @@ func (m *MockReviewControllerI) EXPECT() *MockReviewControllerIMockRecorder {
 }
 
 // CreateReview mocks base method.
-func (m *MockReviewControllerI) CreateReview(reviewData models.CreateReviewRequest, userId *uuid.UUID) (*model.Reviews, string, *models.KTSError) {
+func (m *MockReviewControllerI) CreateReview(reviewData models.CreateReviewRequest, userId *myid.UUID) (*model.Reviews, string, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateReview", reviewData, userId)
 	ret0, _ := ret[0].(*model.Reviews)
@@ -57,7 +57,7 @@ func (mr *MockReviewControllerIMockRecorder) CreateReview(reviewData, userId any
 }
 
 // DeleteReview mocks base method.
-func (m *MockReviewControllerI) DeleteReview(id, userId *uuid.UUID) *models.KTSError {
+func (m *MockReviewControllerI) DeleteReview(id, userId *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteReview", id, userId)
 	ret0, _ := ret[0].(*models.KTSError)

--- a/src/mocks/review_repository_mock.go
+++ b/src/mocks/review_repository_mock.go
@@ -13,7 +13,7 @@ import (
 
 	model "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	models "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	uuid "github.com/google/uuid"
+	myid "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -55,7 +55,7 @@ func (mr *MockReviewRepositoryIMockRecorder) CreateReview(review any) *gomock.Ca
 }
 
 // DeleteReview mocks base method.
-func (m *MockReviewRepositoryI) DeleteReview(id *uuid.UUID) *models.KTSError {
+func (m *MockReviewRepositoryI) DeleteReview(id *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteReview", id)
 	ret0, _ := ret[0].(*models.KTSError)
@@ -69,7 +69,7 @@ func (mr *MockReviewRepositoryIMockRecorder) DeleteReview(id any) *gomock.Call {
 }
 
 // DeleteReviewForMovie mocks base method.
-func (m *MockReviewRepositoryI) DeleteReviewForMovie(movieId *uuid.UUID) *models.KTSError {
+func (m *MockReviewRepositoryI) DeleteReviewForMovie(movieId *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteReviewForMovie", movieId)
 	ret0, _ := ret[0].(*models.KTSError)
@@ -83,7 +83,7 @@ func (mr *MockReviewRepositoryIMockRecorder) DeleteReviewForMovie(movieId any) *
 }
 
 // GetReviewById mocks base method.
-func (m *MockReviewRepositoryI) GetReviewById(id *uuid.UUID) (*model.Reviews, *models.KTSError) {
+func (m *MockReviewRepositoryI) GetReviewById(id *myid.UUID) (*model.Reviews, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetReviewById", id)
 	ret0, _ := ret[0].(*model.Reviews)

--- a/src/mocks/theatre_controller_mock.go
+++ b/src/mocks/theatre_controller_mock.go
@@ -13,7 +13,7 @@ import (
 
 	model "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	models "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	uuid "github.com/google/uuid"
+	myid "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -54,6 +54,20 @@ func (mr *MockTheatreControllerIMockRecorder) CreateCinemaHall(arg0 any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCinemaHall", reflect.TypeOf((*MockTheatreControllerI)(nil).CreateCinemaHall), arg0)
 }
 
+// CreateCinemaHallFast mocks base method.
+func (m *MockTheatreControllerI) CreateCinemaHallFast(arg0 *models.CreateCinemaHallRequest) *models.KTSError {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateCinemaHallFast", arg0)
+	ret0, _ := ret[0].(*models.KTSError)
+	return ret0
+}
+
+// CreateCinemaHallFast indicates an expected call of CreateCinemaHallFast.
+func (mr *MockTheatreControllerIMockRecorder) CreateCinemaHallFast(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCinemaHallFast", reflect.TypeOf((*MockTheatreControllerI)(nil).CreateCinemaHallFast), arg0)
+}
+
 // CreateTheatre mocks base method.
 func (m *MockTheatreControllerI) CreateTheatre(arg0 *models.CreateTheatreRequest) *models.KTSError {
 	m.ctrl.T.Helper()
@@ -69,7 +83,7 @@ func (mr *MockTheatreControllerIMockRecorder) CreateTheatre(arg0 any) *gomock.Ca
 }
 
 // GetCinemaHallsForTheatre mocks base method.
-func (m *MockTheatreControllerI) GetCinemaHallsForTheatre(arg0 *uuid.UUID) (*[]model.CinemaHalls, *models.KTSError) {
+func (m *MockTheatreControllerI) GetCinemaHallsForTheatre(arg0 *myid.UUID) (*[]model.CinemaHalls, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCinemaHallsForTheatre", arg0)
 	ret0, _ := ret[0].(*[]model.CinemaHalls)

--- a/src/mocks/theatre_repository_mock.go
+++ b/src/mocks/theatre_repository_mock.go
@@ -13,7 +13,7 @@ import (
 
 	model "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	models "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	uuid "github.com/google/uuid"
+	myid "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -82,6 +82,20 @@ func (mr *MockTheaterRepoIMockRecorder) CreateSeat(seat any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSeat", reflect.TypeOf((*MockTheaterRepoI)(nil).CreateSeat), seat)
 }
 
+// CreateSeats mocks base method.
+func (m *MockTheaterRepoI) CreateSeats(seat []model.Seats) *models.KTSError {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateSeats", seat)
+	ret0, _ := ret[0].(*models.KTSError)
+	return ret0
+}
+
+// CreateSeats indicates an expected call of CreateSeats.
+func (mr *MockTheaterRepoIMockRecorder) CreateSeats(seat any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSeats", reflect.TypeOf((*MockTheaterRepoI)(nil).CreateSeats), seat)
+}
+
 // CreateTheatre mocks base method.
 func (m *MockTheaterRepoI) CreateTheatre(theatre model.Theatres) *models.KTSError {
 	m.ctrl.T.Helper()
@@ -97,7 +111,7 @@ func (mr *MockTheaterRepoIMockRecorder) CreateTheatre(theatre any) *gomock.Call 
 }
 
 // GetCinemaHallsForTheatre mocks base method.
-func (m *MockTheaterRepoI) GetCinemaHallsForTheatre(theatreId *uuid.UUID) (*[]model.CinemaHalls, *models.KTSError) {
+func (m *MockTheaterRepoI) GetCinemaHallsForTheatre(theatreId *myid.UUID) (*[]model.CinemaHalls, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCinemaHallsForTheatre", theatreId)
 	ret0, _ := ret[0].(*[]model.CinemaHalls)
@@ -127,7 +141,7 @@ func (mr *MockTheaterRepoIMockRecorder) GetSeatCategories() *gomock.Call {
 }
 
 // GetSeatsForCinemaHall mocks base method.
-func (m *MockTheaterRepoI) GetSeatsForCinemaHall(cinemaHallId *uuid.UUID) ([]model.Seats, *models.KTSError) {
+func (m *MockTheaterRepoI) GetSeatsForCinemaHall(cinemaHallId *myid.UUID) ([]model.Seats, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSeatsForCinemaHall", cinemaHallId)
 	ret0, _ := ret[0].([]model.Seats)

--- a/src/mocks/ticket_controller_mock.go
+++ b/src/mocks/ticket_controller_mock.go
@@ -12,7 +12,7 @@ import (
 	reflect "reflect"
 
 	models "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	uuid "github.com/google/uuid"
+	myid "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -40,7 +40,7 @@ func (m *MockTicketControllerI) EXPECT() *MockTicketControllerIMockRecorder {
 }
 
 // GetTicketById mocks base method.
-func (m *MockTicketControllerI) GetTicketById(id *uuid.UUID) (*models.TicketDTO, *models.KTSError) {
+func (m *MockTicketControllerI) GetTicketById(id *myid.UUID) (*models.TicketDTO, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTicketById", id)
 	ret0, _ := ret[0].(*models.TicketDTO)
@@ -55,7 +55,7 @@ func (mr *MockTicketControllerIMockRecorder) GetTicketById(id any) *gomock.Call 
 }
 
 // ValidateTicket mocks base method.
-func (m *MockTicketControllerI) ValidateTicket(id *uuid.UUID) *models.KTSError {
+func (m *MockTicketControllerI) ValidateTicket(id *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateTicket", id)
 	ret0, _ := ret[0].(*models.KTSError)

--- a/src/mocks/ticket_repository_mock.go
+++ b/src/mocks/ticket_repository_mock.go
@@ -13,7 +13,7 @@ import (
 
 	model "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	models "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	uuid "github.com/google/uuid"
+	myid "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -41,10 +41,10 @@ func (m *MockTicketRepositoryI) EXPECT() *MockTicketRepositoryIMockRecorder {
 }
 
 // CreateTicket mocks base method.
-func (m *MockTicketRepositoryI) CreateTicket(ticket *model.Tickets) (*uuid.UUID, *models.KTSError) {
+func (m *MockTicketRepositoryI) CreateTicket(ticket *model.Tickets) (*myid.UUID, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateTicket", ticket)
-	ret0, _ := ret[0].(*uuid.UUID)
+	ret0, _ := ret[0].(*myid.UUID)
 	ret1, _ := ret[1].(*models.KTSError)
 	return ret0, ret1
 }
@@ -56,7 +56,7 @@ func (mr *MockTicketRepositoryIMockRecorder) CreateTicket(ticket any) *gomock.Ca
 }
 
 // GetTicketById mocks base method.
-func (m *MockTicketRepositoryI) GetTicketById(id *uuid.UUID) (*models.TicketDTO, *models.KTSError) {
+func (m *MockTicketRepositoryI) GetTicketById(id *myid.UUID) (*models.TicketDTO, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTicketById", id)
 	ret0, _ := ret[0].(*models.TicketDTO)
@@ -71,7 +71,7 @@ func (mr *MockTicketRepositoryIMockRecorder) GetTicketById(id any) *gomock.Call 
 }
 
 // ValidateTicket mocks base method.
-func (m *MockTicketRepositoryI) ValidateTicket(id *uuid.UUID) *models.KTSError {
+func (m *MockTicketRepositoryI) ValidateTicket(id *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateTicket", id)
 	ret0, _ := ret[0].(*models.KTSError)

--- a/src/mocks/user_movies_repository_mock.go
+++ b/src/mocks/user_movies_repository_mock.go
@@ -12,7 +12,7 @@ import (
 	reflect "reflect"
 
 	models "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	uuid "github.com/google/uuid"
+	myid "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -40,7 +40,7 @@ func (m *MockUserMovieRepositoryI) EXPECT() *MockUserMovieRepositoryIMockRecorde
 }
 
 // RemoveAllUserMovieCombinationWithMovie mocks base method.
-func (m *MockUserMovieRepositoryI) RemoveAllUserMovieCombinationWithMovie(movieId *uuid.UUID) *models.KTSError {
+func (m *MockUserMovieRepositoryI) RemoveAllUserMovieCombinationWithMovie(movieId *myid.UUID) *models.KTSError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveAllUserMovieCombinationWithMovie", movieId)
 	ret0, _ := ret[0].(*models.KTSError)

--- a/src/mocks/user_repo_mock.go
+++ b/src/mocks/user_repo_mock.go
@@ -13,7 +13,7 @@ import (
 
 	model "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	models "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	uuid "github.com/google/uuid"
+	myid "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -83,7 +83,7 @@ func (mr *MockUserRepositoryIMockRecorder) CreateUser(user any) *gomock.Call {
 }
 
 // GetUserById mocks base method.
-func (m *MockUserRepositoryI) GetUserById(id *uuid.UUID) (*model.Users, *models.KTSError) {
+func (m *MockUserRepositoryI) GetUserById(id *myid.UUID) (*model.Users, *models.KTSError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUserById", id)
 	ret0, _ := ret[0].(*model.Users)

--- a/src/models/eventmodels.go
+++ b/src/models/eventmodels.go
@@ -2,13 +2,13 @@ package models
 
 import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 type CreateEvtDTO struct {
 	model.Events
 
-	Movies []*uuid.UUID
+	Movies []*myid.UUID
 
 	EventSeatCategories []model.EventSeatCategories
 }

--- a/src/models/eventseatsmodels.go
+++ b/src/models/eventseatsmodels.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 type GetEventSeatsDTO struct {
@@ -24,7 +24,7 @@ type GetSlectedSeatsDTO struct {
 }
 
 type GetSeatsForSeatSelectorDTO struct {
-	ID             *uuid.UUID
+	ID             *myid.UUID
 	RowNr          int32
 	ColumnNr       int32
 	Available      bool

--- a/src/models/idmodels.go
+++ b/src/models/idmodels.go
@@ -1,7 +1,7 @@
 package models
 
-import "github.com/google/uuid"
+import "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 
 type IdResponse struct {
-	Id *uuid.UUID `json:"id"`
+	Id *myid.UUID `json:"id"`
 }

--- a/src/models/moviesmodels.go
+++ b/src/models/moviesmodels.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 type MovieWithGenres struct {
@@ -48,15 +48,15 @@ type MovieDTOCreate struct {
 	model.Movies
 
 	GenresID []struct {
-		ID *uuid.UUID
+		ID *myid.UUID
 	}
 
 	ActorsID []struct {
-		ID *uuid.UUID
+		ID *myid.UUID
 	}
 
 	ProducersID []struct {
-		ID *uuid.UUID
+		ID *myid.UUID
 	}
 }
 

--- a/src/models/ordermodels.go
+++ b/src/models/ordermodels.go
@@ -2,16 +2,16 @@ package models
 
 import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 type CreateOrderDTO struct {
 	EventSeatPriceCategories []struct {
-		EventSeatId     *uuid.UUID
-		PriceCategoryId *uuid.UUID
+		EventSeatId     *myid.UUID
+		PriceCategoryId *myid.UUID
 	}
 
-	PaymentMethodID *uuid.UUID
+	PaymentMethodID *myid.UUID
 }
 
 type GetOrderDTO struct {

--- a/src/models/theatre_models.go
+++ b/src/models/theatre_models.go
@@ -1,6 +1,6 @@
 package models
 
-import "github.com/google/uuid"
+import "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 
 type CreateTheatreRequest struct {
 	Name    string
@@ -22,5 +22,5 @@ type CreateCinemaHallRequest struct {
 		Type     string
 		Category string
 	}
-	TheatreId *uuid.UUID
+	TheatreId *myid.UUID
 }

--- a/src/models/ticketmodels.go
+++ b/src/models/ticketmodels.go
@@ -2,11 +2,11 @@ package models
 
 import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 type TicketDTO struct {
-	ID        *uuid.UUID `sql:"primary_key" alias:"ticket.id"`
+	ID        *myid.UUID `sql:"primary_key" alias:"ticket.id"`
 	Validated bool       `alias:"ticket.validated"`
 	Price     int32      `alias:"ticket.price"`
 

--- a/src/models/user_models.go
+++ b/src/models/user_models.go
@@ -2,7 +2,7 @@ package models
 
 import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 type RegistrationRequest struct {
@@ -34,5 +34,5 @@ type CheckUsernameRequest struct {
 
 type LoggedInResponse struct {
 	LoggedIn bool       `json:"loggedIn"`
-	Id       *uuid.UUID `json:"id"`
+	Id       *myid.UUID `json:"id"`
 }

--- a/src/myid/myid.go
+++ b/src/myid/myid.go
@@ -1,0 +1,38 @@
+package myid
+
+import (
+	"database/sql/driver"
+
+	"github.com/google/uuid"
+)
+
+type UUID struct {
+	uuid.UUID
+}
+
+func (u UUID) Value() (driver.Value, error) {
+	return u.MarshalBinary()
+}
+
+func Parse(str string) (UUID, error) {
+	uuid, err := uuid.Parse(str)
+	if err != nil {
+		return UUID{}, err
+	}
+	return UUID{uuid}, nil
+}
+
+func MustParse(str string) UUID {
+	uuid := uuid.MustParse(str)
+	return UUID{uuid}
+}
+
+func New() UUID {
+	uuid := uuid.New()
+	return UUID{uuid}
+}
+
+func NewUUID() *UUID {
+	uuid := uuid.New()
+	return &UUID{uuid}
+}

--- a/src/repositories/actor_repository.go
+++ b/src/repositories/actor_repository.go
@@ -6,26 +6,26 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/table"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/managers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
 
 	"github.com/go-jet/jet/v2/mysql"
-	"github.com/google/uuid"
 )
 
 type ActorRepoI interface {
-	GetActorById(actorId *uuid.UUID) (*models.ActorDTO, *models.KTSError)
+	GetActorById(actorId *myid.UUID) (*models.ActorDTO, *models.KTSError)
 	GetActors() (*[]models.GetActorsDTO, *models.KTSError)
-	CreateActor(actor *model.Actors) (*uuid.UUID, *models.KTSError)
+	CreateActor(actor *model.Actors) (*myid.UUID, *models.KTSError)
 
 	// Actor pictures
-	CreateActorPicture(actorPicture *model.ActorPictures) (*uuid.UUID, *models.KTSError)
+	CreateActorPicture(actorPicture *model.ActorPictures) (*myid.UUID, *models.KTSError)
 }
 
 type ActorRepository struct {
 	DatabaseManager *managers.DatabaseManager
 }
 
-func (ar *ActorRepository) GetActorById(actorId *uuid.UUID) (*models.ActorDTO, *models.KTSError) {
+func (ar *ActorRepository) GetActorById(actorId *myid.UUID) (*models.ActorDTO, *models.KTSError) {
 	var actor models.ActorDTO
 
 	stmt := mysql.SELECT(
@@ -40,7 +40,7 @@ func (ar *ActorRepository) GetActorById(actorId *uuid.UUID) (*models.ActorDTO, *
 				LEFT_JOIN(table.Movies, table.Movies.ID.EQ(table.MovieActors.MovieID)),
 		).
 		WHERE(
-			table.Actors.ID.EQ(utils.MysqlUuid(actorId)),
+			table.Actors.ID.EQ(utils.MysqlUuid(*actorId)),
 		)
 
 	err := stmt.Query(ar.DatabaseManager.GetDatabaseConnection(), &actor)
@@ -77,8 +77,8 @@ func (ar *ActorRepository) GetActors() (*[]models.GetActorsDTO, *models.KTSError
 	return &actors, nil
 }
 
-func (ar *ActorRepository) CreateActor(actor *model.Actors) (*uuid.UUID, *models.KTSError) {
-	actor.ID = utils.NewUUID()
+func (ar *ActorRepository) CreateActor(actor *model.Actors) (*myid.UUID, *models.KTSError) {
+	actor.ID = myid.New()
 
 	insertStmt := table.Actors.INSERT(table.Actors.AllColumns).VALUES(
 		utils.MysqlUuid(actor.ID),
@@ -103,11 +103,11 @@ func (ar *ActorRepository) CreateActor(actor *model.Actors) (*uuid.UUID, *models
 		return nil, kts_errors.KTS_INTERNAL_ERROR
 	}
 
-	return actor.ID, nil
+	return &actor.ID, nil
 }
 
-func (ar *ActorRepository) CreateActorPicture(actorPicture *model.ActorPictures) (*uuid.UUID, *models.KTSError) {
-	actorPicture.ID = utils.NewUUID()
+func (ar *ActorRepository) CreateActorPicture(actorPicture *model.ActorPictures) (*myid.UUID, *models.KTSError) {
+	actorPicture.ID = myid.New()
 
 	insertStmt := table.ActorPictures.INSERT(table.ActorPictures.AllColumns).VALUES(
 		utils.MysqlUuid(actorPicture.ID),
@@ -131,5 +131,5 @@ func (ar *ActorRepository) CreateActorPicture(actorPicture *model.ActorPictures)
 		return nil, kts_errors.KTS_INTERNAL_ERROR
 	}
 
-	return actorPicture.ID, nil
+	return &actorPicture.ID, nil
 }

--- a/src/repositories/actor_repository_test.go
+++ b/src/repositories/actor_repository_test.go
@@ -6,13 +6,13 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/managers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/samples"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
 )
@@ -23,7 +23,7 @@ func TestGetActorById(t *testing.T) {
 
 	actor := *samples.GetSampleActor()
 
-	id := uuid.MustParse(actor.ID.String())
+	id := myid.MustParse(actor.ID.String())
 
 	testCases := []struct {
 		name            string
@@ -34,7 +34,7 @@ func TestGetActorById(t *testing.T) {
 		{
 			name: "Select actor by id",
 			setExpectations: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(query).WithArgs(utils.EqUUID(&id)).
+				mock.ExpectQuery(query).WithArgs(utils.EqUUID(id)).
 					WillReturnRows(sqlmock.NewRows([]string{"actors.id", "actors.name", "actors.birthdate", "actors.description", "actor_pictures.id", "actor_pictures.actor_id", "actor_pictures.pic_url", "movies.id", "movies.title", "movies.description", "movies.banner_pic_url", "movies.cover_pic_url", "movies.trailer_url", "movies.rating", "movies.release_date", "movies.time_in_min", "movies.fsk"}).
 						AddRow(actor.ID, actor.Name, actor.Birthdate, actor.Description, actor.Pictures[0].ID, actor.Pictures[0].ActorID, actor.Pictures[0].PicURL, actor.Movies[0].ID, actor.Movies[0].Title, actor.Movies[0].Description, actor.Movies[0].BannerPicURL, actor.Movies[0].CoverPicURL, actor.Movies[0].TrailerURL, actor.Movies[0].Rating, actor.Movies[0].ReleaseDate, actor.Movies[0].TimeInMin, actor.Movies[0].Fsk).
 						AddRow(actor.ID, actor.Name, actor.Birthdate, actor.Description, actor.Pictures[1].ID, actor.Pictures[1].ActorID, actor.Pictures[1].PicURL, actor.Movies[0].ID, actor.Movies[0].Title, actor.Movies[0].Description, actor.Movies[0].BannerPicURL, actor.Movies[0].CoverPicURL, actor.Movies[0].TrailerURL, actor.Movies[0].Rating, actor.Movies[0].ReleaseDate, actor.Movies[0].TimeInMin, actor.Movies[0].Fsk).
@@ -49,7 +49,7 @@ func TestGetActorById(t *testing.T) {
 		{
 			name: "Select actor by id - no actor found",
 			setExpectations: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(query).WithArgs(utils.EqUUID(&id)).
+				mock.ExpectQuery(query).WithArgs(utils.EqUUID(id)).
 					WillReturnRows(sqlmock.NewRows([]string{"actors.id", "actors.name", "actors.birthdate", "actors.description", "actor_pictures.id", "actor_pictures.actor_id", "actor_pictures.pic_url", "movies.id", "movies.title", "movies.description", "movies.banner_pic_url", "movies.cover_pic_url", "movies.trailer_url", "movies.rating", "movies.release_date", "movies.time_in_min", "movies.fsk"}))
 			},
 			expectedActor: nil,
@@ -257,7 +257,7 @@ func TestCreateActorPicture(t *testing.T) {
 	picUrl := "pic.jpg"
 
 	ActorPicture := &model.ActorPictures{
-		ActorID: utils.NewUUID(),
+		ActorID: myid.New(),
 		PicURL:  &picUrl,
 	}
 

--- a/src/repositories/event_repository_test.go
+++ b/src/repositories/event_repository_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/managers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/samples"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
 )
@@ -25,7 +26,7 @@ func TestCreateEvent(t *testing.T) {
 		End:          time.Now().Add(time.Hour),
 		Description:  &description,
 		EventType:    "Test event type",
-		CinemaHallID: utils.NewUUID(),
+		CinemaHallID: myid.New(),
 	}
 
 	testCases := []struct {
@@ -94,8 +95,8 @@ func TestCreateEvent(t *testing.T) {
 }
 func TestCreateEventSeatCategory(t *testing.T) {
 	eventSeatCategory := &model.EventSeatCategories{
-		EventID:        utils.NewUUID(),
-		SeatCategoryID: utils.NewUUID(),
+		EventID:        myid.New(),
+		SeatCategoryID: myid.New(),
 		Price:          999,
 	}
 
@@ -165,8 +166,8 @@ func TestCreateEventSeatCategory(t *testing.T) {
 }
 
 func TestAddEventMovie(t *testing.T) {
-	eventID := utils.NewUUID()
-	movieID := utils.NewUUID()
+	eventID := myid.NewUUID()
+	movieID := myid.NewUUID()
 
 	testCases := []struct {
 		name            string
@@ -227,9 +228,9 @@ func TestAddEventMovie(t *testing.T) {
 
 func TestCreateEventSeat(t *testing.T) {
 	eventSeat := &model.EventSeats{
-		ID:      utils.NewUUID(),
-		EventID: utils.NewUUID(),
-		SeatID:  utils.NewUUID(),
+		ID:      myid.New(),
+		EventID: myid.New(),
+		SeatID:  myid.New(),
 		Booked:  false,
 	}
 
@@ -290,27 +291,27 @@ func TestCreateEventSeat(t *testing.T) {
 	}
 }
 func TestGetEventsForMovie(t *testing.T) {
-	movieID := utils.NewUUID()
-	theatreId := utils.NewUUID()
+	movieID := myid.NewUUID()
+	theatreId := myid.NewUUID()
 
 	expectedEvents := []*model.Events{
 		{
-			ID:           utils.NewUUID(),
+			ID:           myid.New(),
 			Title:        "Test Event 1",
 			Start:        time.Now(),
 			End:          time.Now().Add(time.Hour),
 			Description:  utils.GetStringPointer("Test event description 1"),
 			EventType:    "showing",
-			CinemaHallID: utils.NewUUID(),
+			CinemaHallID: myid.New(),
 		},
 		{
-			ID:           utils.NewUUID(),
+			ID:           myid.New(),
 			Title:        "Test Event 2",
 			Start:        time.Now(),
 			End:          time.Now().Add(time.Hour),
 			Description:  utils.GetStringPointer("Test event description 2"),
 			EventType:    "showing",
-			CinemaHallID: utils.NewUUID(),
+			CinemaHallID: myid.New(),
 		},
 	}
 
@@ -379,7 +380,7 @@ func TestGetSpecialEvents(t *testing.T) {
 	expectedSpecialEvents := []models.GetSpecialEventsDTO{
 		{
 			Events: model.Events{
-				ID:          utils.NewUUID(),
+				ID:          myid.New(),
 				Title:       "Special Event 1",
 				Start:       time.Now(),
 				End:         time.Now().Add(time.Hour),
@@ -387,14 +388,14 @@ func TestGetSpecialEvents(t *testing.T) {
 			},
 			Movies: []*model.Movies{
 				{
-					ID:    utils.NewUUID(),
+					ID:    myid.New(),
 					Title: "Movie 1",
 				},
 			},
 		},
 		{
 			Events: model.Events{
-				ID:          utils.NewUUID(),
+				ID:          myid.New(),
 				Title:       "Special Event 2",
 				Start:       time.Now(),
 				End:         time.Now().Add(time.Hour),
@@ -402,7 +403,7 @@ func TestGetSpecialEvents(t *testing.T) {
 			},
 			Movies: []*model.Movies{
 				{
-					ID:    utils.NewUUID(),
+					ID:    myid.New(),
 					Title: "Movie 2",
 				},
 			},
@@ -481,7 +482,7 @@ func TestGetSpecialEvents(t *testing.T) {
 }
 
 func TestGetEventById(t *testing.T) {
-	eventID := utils.NewUUID()
+	eventID := myid.NewUUID()
 
 	expectedEvent := samples.GetGetSpecialEventsDTO(eventID)
 
@@ -496,7 +497,7 @@ func TestGetEventById(t *testing.T) {
 		{
 			name: "Get event by ID",
 			setExpectations: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(query).WithArgs(utils.EqUUID(eventID)).
+				mock.ExpectQuery(query).WithArgs(utils.EqUUID(*eventID)).
 					WillReturnRows(sqlmock.NewRows([]string{
 						"events.id", "events.title", "events.start", "events.end", "events.description", "events.event_type", "events.cinema_hall_id",
 						"movies.id", "movies.title", "movies.description", "movies.banner_pic_url", "movies.cover_pic_url",
@@ -517,7 +518,7 @@ func TestGetEventById(t *testing.T) {
 		{
 			name: "Get event by ID sql error",
 			setExpectations: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(query).WithArgs(utils.EqUUID(eventID)).WillReturnError(sql.ErrConnDone)
+				mock.ExpectQuery(query).WithArgs(utils.EqUUID(*eventID)).WillReturnError(sql.ErrConnDone)
 			},
 			expectedEvent: nil,
 			expectedError: kts_errors.KTS_INTERNAL_ERROR,

--- a/src/repositories/eventseat_repository_test.go
+++ b/src/repositories/eventseat_repository_test.go
@@ -6,6 +6,7 @@ import (
 
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/managers"
@@ -15,17 +16,17 @@ import (
 )
 
 func GetEventSeats() *[]models.GetEventSeatsDTO {
-	seatId := utils.NewUUID()
-	seatCategoryId := utils.NewUUID()
+	seatId := myid.New()
+	seatCategoryId := myid.New()
 
 	eventSeats := []models.GetEventSeatsDTO{
 		{
 			EventSeat: model.EventSeats{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				Booked:       false,
 				BlockedUntil: nil,
 				UserID:       nil,
-				EventID:      utils.NewUUID(),
+				EventID:      myid.New(),
 				SeatID:       seatId,
 			},
 			Seat: model.Seats{
@@ -40,18 +41,18 @@ func GetEventSeats() *[]models.GetEventSeatsDTO {
 				CategoryName: "standard",
 			},
 			EventSeatCategory: model.EventSeatCategories{
-				EventID:        utils.NewUUID(),
+				EventID:        myid.New(),
 				SeatCategoryID: seatCategoryId,
 				Price:          100,
 			},
 		},
 		{
 			EventSeat: model.EventSeats{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				Booked:       false,
 				BlockedUntil: nil,
 				UserID:       nil,
-				EventID:      utils.NewUUID(),
+				EventID:      myid.New(),
 				SeatID:       seatId,
 			},
 			Seat: model.Seats{
@@ -65,7 +66,7 @@ func GetEventSeats() *[]models.GetEventSeatsDTO {
 				CategoryName: "standard",
 			},
 			EventSeatCategory: model.EventSeatCategories{
-				EventID:        utils.NewUUID(),
+				EventID:        myid.New(),
 				SeatCategoryID: seatCategoryId,
 				Price:          100,
 			},
@@ -141,7 +142,7 @@ func TestGetEventSeats(t *testing.T) {
 			tc.setExpectations(mock)
 
 			// Call the method on the repository instance
-			seats, kts_err := eventSeatRepo.GetEventSeats(eventSeats[0].EventSeat.EventID)
+			seats, kts_err := eventSeatRepo.GetEventSeats(&eventSeats[0].EventSeat.EventID)
 
 			// Verify that all expectations were met
 
@@ -160,9 +161,9 @@ func TestGetEventSeats(t *testing.T) {
 }
 
 func TestBlockEventSeatIfAvailable(t *testing.T) {
-	eventId := utils.NewUUID()
-	seatId := utils.NewUUID()
-	userId := utils.NewUUID()
+	eventId := myid.NewUUID()
+	seatId := myid.NewUUID()
+	userId := myid.NewUUID()
 	blockedUntil := time.Now()
 
 	query := "UPDATE `KinoTicketSystem`.event_seats SET .* WHERE .*"
@@ -232,8 +233,8 @@ func TestBlockEventSeatIfAvailable(t *testing.T) {
 	}
 }
 func TestUpdateBlockedUntilTimeForUserEventSeats(t *testing.T) {
-	eventId := utils.NewUUID()
-	userId := utils.NewUUID()
+	eventId := myid.NewUUID()
+	userId := myid.NewUUID()
 	blockedUntil := time.Now()
 
 	query := "UPDATE `KinoTicketSystem`.event_seats SET .* WHERE .*"
@@ -309,9 +310,9 @@ func TestUpdateBlockedUntilTimeForUserEventSeats(t *testing.T) {
 }
 
 func TestUnblockEventSeat(t *testing.T) {
-	eventId := utils.NewUUID()
-	seatId := utils.NewUUID()
-	userId := utils.NewUUID()
+	eventId := myid.NewUUID()
+	seatId := myid.NewUUID()
+	userId := myid.NewUUID()
 
 	query := "UPDATE `KinoTicketSystem`.event_seats SET .* WHERE .*"
 
@@ -380,8 +381,8 @@ func TestUnblockEventSeat(t *testing.T) {
 }
 
 func TestUnblockAllEventSeats(t *testing.T) {
-	eventId := utils.NewUUID()
-	userId := utils.NewUUID()
+	eventId := myid.NewUUID()
+	userId := myid.NewUUID()
 
 	query := "UPDATE" // `KinoTicketSystem`.event_seats SET .* WHERE .*"
 
@@ -399,8 +400,8 @@ func TestUnblockAllEventSeats(t *testing.T) {
 					WithArgs(
 						nil,
 						nil,
-						utils.EqUUID(eventId),
-						utils.EqUUID(userId),
+						utils.EqUUID(*eventId),
+						utils.EqUUID(*userId),
 					).WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 			expectedError: nil,
@@ -412,8 +413,8 @@ func TestUnblockAllEventSeats(t *testing.T) {
 					WithArgs(
 						nil,
 						nil,
-						utils.EqUUID(eventId),
-						utils.EqUUID(userId),
+						utils.EqUUID(*eventId),
+						utils.EqUUID(*userId),
 					).WillReturnResult(sqlmock.NewResult(0, 0))
 			},
 			expectedError: kts_errors.KTS_NOT_FOUND,
@@ -425,8 +426,8 @@ func TestUnblockAllEventSeats(t *testing.T) {
 					WithArgs(
 						nil,
 						nil,
-						utils.EqUUID(eventId),
-						utils.EqUUID(userId),
+						utils.EqUUID(*eventId),
+						utils.EqUUID(*userId),
 					).WillReturnError(sqlmock.ErrCancelled)
 			},
 			expectedError: kts_errors.KTS_INTERNAL_ERROR,
@@ -438,8 +439,8 @@ func TestUnblockAllEventSeats(t *testing.T) {
 					WithArgs(
 						nil,
 						nil,
-						utils.EqUUID(eventId),
-						utils.EqUUID(userId),
+						utils.EqUUID(*eventId),
+						utils.EqUUID(*userId),
 					).WillReturnResult(sqlmock.NewErrorResult(sqlmock.ErrCancelled))
 			},
 			expectedError: kts_errors.KTS_INTERNAL_ERROR,
@@ -477,57 +478,57 @@ func TestUnblockAllEventSeats(t *testing.T) {
 }
 
 func TestGetSelectedSeats(t *testing.T) {
-	eventId := utils.NewUUID()
-	userId := utils.NewUUID()
+	eventId := myid.NewUUID()
+	userId := myid.NewUUID()
 
 	eventSeats := []models.GetSlectedSeatsDTO{
 		{
 			EventSeat: model.EventSeats{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				Booked:       false,
 				BlockedUntil: nil,
 				UserID:       nil,
-				EventID:      eventId,
-				SeatID:       utils.NewUUID(),
+				EventID:      *eventId,
+				SeatID:       myid.New(),
 			},
 			Seat: model.Seats{
-				ID:             utils.NewUUID(),
+				ID:             myid.New(),
 				RowNr:          1,
 				ColumnNr:       1,
-				SeatCategoryID: utils.NewUUID(),
+				SeatCategoryID: myid.New(),
 			},
 			SeatCategory: model.SeatCategories{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				CategoryName: "standard",
 			},
 			EventSeatCategory: model.EventSeatCategories{
-				EventID:        eventId,
-				SeatCategoryID: utils.NewUUID(),
+				EventID:        *eventId,
+				SeatCategoryID: myid.New(),
 				Price:          100,
 			},
 		},
 		{
 			EventSeat: model.EventSeats{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				Booked:       false,
 				BlockedUntil: nil,
 				UserID:       nil,
-				EventID:      eventId,
-				SeatID:       utils.NewUUID(),
+				EventID:      *eventId,
+				SeatID:       myid.New(),
 			},
 			Seat: model.Seats{
-				ID:             utils.NewUUID(),
+				ID:             myid.New(),
 				RowNr:          1,
 				ColumnNr:       2,
-				SeatCategoryID: utils.NewUUID(),
+				SeatCategoryID: myid.New(),
 			},
 			SeatCategory: model.SeatCategories{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				CategoryName: "standard",
 			},
 			EventSeatCategory: model.EventSeatCategories{
-				EventID:        eventId,
-				SeatCategoryID: utils.NewUUID(),
+				EventID:        *eventId,
+				SeatCategoryID: myid.New(),
 				Price:          100,
 			},
 		},

--- a/src/repositories/genre_repository.go
+++ b/src/repositories/genre_repository.go
@@ -6,18 +6,18 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/table"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/managers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
 	"github.com/go-jet/jet/v2/mysql"
-	"github.com/google/uuid"
 )
 
 type GenreRepositoryI interface {
 	// Genre
 	GetGenres() (*[]model.Genres, *models.KTSError)
 	GetGenreByName(name *string) (*model.Genres, *models.KTSError)
-	CreateGenre(name *string) (*uuid.UUID, *models.KTSError)
+	CreateGenre(name *string) (*myid.UUID, *models.KTSError)
 	UpdateGenre(genre *model.Genres) *models.KTSError
-	DeleteGenre(genreId *uuid.UUID) *models.KTSError
+	DeleteGenre(genreId *myid.UUID) *models.KTSError
 
 	// All Movies with all Genres - Grouped by Genre
 	GetGenresWithMovies() (*[]models.GenreWithMovies, *models.KTSError)
@@ -75,18 +75,19 @@ func (mr *GenreRepository) GetGenreByName(name *string) (*model.Genres, *models.
 	return &genre, nil
 }
 
-func (mr *GenreRepository) CreateGenre(name *string) (*uuid.UUID, *models.KTSError) {
-	uuid := uuid.New()
+func (mr *GenreRepository) CreateGenre(name *string) (*myid.UUID, *models.KTSError) {
+	uuid := myid.New()
 
 	// Create the insert statement
 	insertQuery := table.Genres.INSERT(
 		table.Genres.ID,
 		table.Genres.GenreName,
-	).
-		VALUES(
-			utils.MysqlUuid(&uuid),
-			name,
-		)
+	).MODEL(
+		model.Genres{
+			ID:        uuid,
+			GenreName: *name,
+		},
+	)
 
 	// Execute the query
 	rows, err := insertQuery.Exec(mr.DatabaseManager.GetDatabaseConnection())
@@ -131,11 +132,11 @@ func (mr *GenreRepository) UpdateGenre(genre *model.Genres) *models.KTSError {
 	return nil
 }
 
-func (mr *GenreRepository) DeleteGenre(genreId *uuid.UUID) *models.KTSError {
+func (mr *GenreRepository) DeleteGenre(genreId *myid.UUID) *models.KTSError {
 
 	// Create the delete statement
 	deleteQuery := table.Genres.DELETE().
-		WHERE(table.Genres.ID.EQ(utils.MysqlUuid(genreId)))
+		WHERE(table.Genres.ID.EQ(utils.MysqlUuid(*genreId)))
 
 	// Execute the query
 	rows, err := deleteQuery.Exec(mr.DatabaseManager.GetDatabaseConnection())

--- a/src/repositories/genre_repository_test.go
+++ b/src/repositories/genre_repository_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/managers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/samples"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -339,33 +339,33 @@ func TestUpdateGenre(t *testing.T) {
 }
 
 func TestDeleteGenre(t *testing.T) {
-	genreId := uuid.New()
+	genreId := myid.New()
 
 	query := "DELETE FROM `KinoTicketSystem`.genres WHERE genres.id = ?;"
 
 	testCases := []struct {
 		name            string
-		setExpectations func(mock sqlmock.Sqlmock, genre *uuid.UUID)
+		setExpectations func(mock sqlmock.Sqlmock, genre *myid.UUID)
 		expectedError   *models.KTSError
 	}{
 		{
 			name: "Successful deletion",
-			setExpectations: func(mock sqlmock.Sqlmock, genre *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&genreId)).WillReturnResult(sqlmock.NewResult(1, 1))
+			setExpectations: func(mock sqlmock.Sqlmock, genre *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(genreId)).WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 			expectedError: nil,
 		},
 		{
 			name: "Error while deleting genre",
-			setExpectations: func(mock sqlmock.Sqlmock, genre *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&genreId)).WillReturnError(sqlmock.ErrCancelled)
+			setExpectations: func(mock sqlmock.Sqlmock, genre *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(genreId)).WillReturnError(sqlmock.ErrCancelled)
 			},
 			expectedError: kts_errors.KTS_INTERNAL_ERROR,
 		},
 		{
 			name: "Error while converting rows affected",
-			setExpectations: func(mock sqlmock.Sqlmock, genre *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&genreId)).WillReturnResult(
+			setExpectations: func(mock sqlmock.Sqlmock, genre *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(genreId)).WillReturnResult(
 					sqlmock.NewErrorResult(errors.New("rows affected conversion did not work")),
 				)
 			},
@@ -373,8 +373,8 @@ func TestDeleteGenre(t *testing.T) {
 		},
 		{
 			name: "Genre not found",
-			setExpectations: func(mock sqlmock.Sqlmock, genre *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&genreId)).WillReturnResult(sqlmock.NewResult(1, 0))
+			setExpectations: func(mock sqlmock.Sqlmock, genre *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(genreId)).WillReturnResult(sqlmock.NewResult(1, 0))
 			},
 			expectedError: kts_errors.KTS_NOT_FOUND,
 		},

--- a/src/repositories/movie_actor_repository.go
+++ b/src/repositories/movie_actor_repository.go
@@ -5,14 +5,14 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/table"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/managers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
 )
 
 type MovieActorRepositoryI interface {
-	AddMovieActor(movieId *uuid.UUID, actorId *uuid.UUID) *models.KTSError
-	RemoveMovieActor(movieId *uuid.UUID, actorId *uuid.UUID) *models.KTSError
-	RemoveAllActorCombinationWithMovie(movieId *uuid.UUID) *models.KTSError
+	AddMovieActor(movieId *myid.UUID, actorId *myid.UUID) *models.KTSError
+	RemoveMovieActor(movieId *myid.UUID, actorId *myid.UUID) *models.KTSError
+	RemoveAllActorCombinationWithMovie(movieId *myid.UUID) *models.KTSError
 }
 
 type MovieActorRepository struct {
@@ -20,12 +20,12 @@ type MovieActorRepository struct {
 }
 
 // Combine Movie and Genre
-func (mar *MovieActorRepository) AddMovieActor(movieId *uuid.UUID, actorId *uuid.UUID) *models.KTSError {
+func (mar *MovieActorRepository) AddMovieActor(movieId *myid.UUID, actorId *myid.UUID) *models.KTSError {
 	// Create the insert statement
 	insertQuery := table.MovieActors.INSERT(table.MovieActors.MovieID, table.MovieActors.ActorID).
 		VALUES(
-			utils.MysqlUuid(movieId),
-			utils.MysqlUuid(actorId),
+			utils.MysqlUuid(*movieId),
+			utils.MysqlUuid(*actorId),
 		)
 
 	// Execute the query
@@ -46,11 +46,11 @@ func (mar *MovieActorRepository) AddMovieActor(movieId *uuid.UUID, actorId *uuid
 	return nil
 }
 
-func (mar *MovieActorRepository) RemoveMovieActor(movieId *uuid.UUID, actorId *uuid.UUID) *models.KTSError {
+func (mar *MovieActorRepository) RemoveMovieActor(movieId *myid.UUID, actorId *myid.UUID) *models.KTSError {
 
 	deleteQuery := table.MovieGenres.DELETE().WHERE(
-		table.MovieActors.MovieID.EQ(utils.MysqlUuid(movieId)).AND(
-			table.MovieActors.ActorID.EQ(utils.MysqlUuid(actorId)),
+		table.MovieActors.MovieID.EQ(utils.MysqlUuid(*movieId)).AND(
+			table.MovieActors.ActorID.EQ(utils.MysqlUuid(*actorId)),
 		),
 	)
 
@@ -72,9 +72,9 @@ func (mar *MovieActorRepository) RemoveMovieActor(movieId *uuid.UUID, actorId *u
 	return nil
 }
 
-func (mar *MovieActorRepository) RemoveAllActorCombinationWithMovie(movieId *uuid.UUID) *models.KTSError {
+func (mar *MovieActorRepository) RemoveAllActorCombinationWithMovie(movieId *myid.UUID) *models.KTSError {
 	deleteQuery := table.MovieActors.DELETE().WHERE(
-		table.MovieActors.MovieID.EQ(utils.MysqlUuid(movieId)),
+		table.MovieActors.MovieID.EQ(utils.MysqlUuid(*movieId)),
 	)
 
 	// Execute the query

--- a/src/repositories/movie_actor_repository_test.go
+++ b/src/repositories/movie_actor_repository_test.go
@@ -8,41 +8,41 @@ import (
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/managers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAddMovieActor(t *testing.T) {
 
-	uuid1 := uuid.New()
-	uuid2 := uuid.New()
+	uuid1 := myid.New()
+	uuid2 := myid.New()
 
 	query := "INSERT INTO `KinoTicketSystem`.movie_actors (movie_id, actor_id) VALUES (?, ?);"
 
 	testCases := []struct {
 		name            string
-		setExpectations func(mock sqlmock.Sqlmock, movieId *uuid.UUID, actorId *uuid.UUID)
+		setExpectations func(mock sqlmock.Sqlmock, movieId *myid.UUID, actorId *myid.UUID)
 		expectedError   *models.KTSError
 	}{
 		{
 			name: "Create movieActor",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID, actorId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&uuid1), utils.EqUUID(&uuid2)).WillReturnResult(sqlmock.NewResult(1, 1))
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID, actorId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(uuid1), utils.EqUUID(uuid2)).WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 			expectedError: nil,
 		},
 		{
 			name: "Error while creating movieActor",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID, actorId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&uuid1), utils.EqUUID(&uuid2)).WillReturnError(sqlmock.ErrCancelled)
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID, actorId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(uuid1), utils.EqUUID(uuid2)).WillReturnError(sqlmock.ErrCancelled)
 			},
 			expectedError: kts_errors.KTS_INTERNAL_ERROR,
 		},
 		{
 			name: "Error while converting rows affected",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID, actorId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&uuid1), utils.EqUUID(&uuid2)).WillReturnResult(
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID, actorId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(uuid1), utils.EqUUID(uuid2)).WillReturnResult(
 					sqlmock.NewErrorResult(errors.New("rows affected conversion did not work")),
 				)
 			},
@@ -50,8 +50,8 @@ func TestAddMovieActor(t *testing.T) {
 		},
 		{
 			name: "movieActor not found",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID, actorId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&uuid1), utils.EqUUID(&uuid2)).WillReturnResult(sqlmock.NewResult(1, 0))
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID, actorId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(uuid1), utils.EqUUID(uuid2)).WillReturnResult(sqlmock.NewResult(1, 0))
 			},
 			expectedError: kts_errors.KTS_NOT_FOUND,
 		},
@@ -94,34 +94,34 @@ func TestAddMovieActor(t *testing.T) {
 
 func TestRemoveMovieActor(t *testing.T) {
 
-	uuid1 := uuid.New()
-	uuid2 := uuid.New()
+	uuid1 := myid.New()
+	uuid2 := myid.New()
 
 	query := "DELETE FROM `KinoTicketSystem`.movie_genres WHERE (movie_actors.movie_id = ?) AND (movie_actors.actor_id = ?);"
 
 	testCases := []struct {
 		name            string
-		setExpectations func(mock sqlmock.Sqlmock, movieId *uuid.UUID, actorId *uuid.UUID)
+		setExpectations func(mock sqlmock.Sqlmock, movieId *myid.UUID, actorId *myid.UUID)
 		expectedError   *models.KTSError
 	}{
 		{
 			name: "Add movie_actor",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID, actorId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&uuid1), utils.EqUUID(&uuid2)).WillReturnResult(sqlmock.NewResult(1, 1))
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID, actorId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(uuid1), utils.EqUUID(uuid2)).WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 			expectedError: nil,
 		},
 		{
 			name: "Error while adding movie_actor",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID, actorId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&uuid1), utils.EqUUID(&uuid2)).WillReturnError(sqlmock.ErrCancelled)
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID, actorId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(uuid1), utils.EqUUID(uuid2)).WillReturnError(sqlmock.ErrCancelled)
 			},
 			expectedError: kts_errors.KTS_INTERNAL_ERROR,
 		},
 		{
 			name: "Error while converting rows affected",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID, actorId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&uuid1), utils.EqUUID(&uuid2)).WillReturnResult(
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID, actorId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(uuid1), utils.EqUUID(uuid2)).WillReturnResult(
 					sqlmock.NewErrorResult(errors.New("rows affected conversion did not work")),
 				)
 			},
@@ -129,8 +129,8 @@ func TestRemoveMovieActor(t *testing.T) {
 		},
 		{
 			name: "MovieActor not found",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID, actorId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&uuid1), utils.EqUUID(&uuid2)).WillReturnResult(sqlmock.NewResult(1, 0))
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID, actorId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(uuid1), utils.EqUUID(uuid2)).WillReturnResult(sqlmock.NewResult(1, 0))
 			},
 			expectedError: kts_errors.KTS_NOT_FOUND,
 		},
@@ -171,26 +171,26 @@ func TestRemoveMovieActor(t *testing.T) {
 
 func TestRemoveAllActorCombinationWithMovie(t *testing.T) {
 
-	movieId := uuid.New()
+	movieId := myid.New()
 
 	query := "DELETE FROM `KinoTicketSystem`.movie_actors WHERE movie_actors.movie_id = ?;"
 
 	testCases := []struct {
 		name            string
-		setExpectations func(mock sqlmock.Sqlmock, movieId *uuid.UUID)
+		setExpectations func(mock sqlmock.Sqlmock, movieId *myid.UUID)
 		expectedError   *models.KTSError
 	}{
 		{
 			name: "Remove all actors corresponding to one movie",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(movieId)).WillReturnResult(sqlmock.NewResult(1, 1))
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(*movieId)).WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 			expectedError: nil,
 		},
 		{
 			name: "Error while removing movie_actor",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(movieId)).WillReturnError(sqlmock.ErrCancelled)
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(*movieId)).WillReturnError(sqlmock.ErrCancelled)
 			},
 			expectedError: kts_errors.KTS_INTERNAL_ERROR,
 		},

--- a/src/repositories/movie_genres_repository.go
+++ b/src/repositories/movie_genres_repository.go
@@ -5,16 +5,16 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/table"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/managers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
 )
 
 type MovieGenreRepositoryI interface {
 	// Combine Movie and Genre
-	AddMovieGenre(movieId *uuid.UUID, genreId *uuid.UUID) *models.KTSError
-	RemoveMovieGenre(movieId *uuid.UUID, genreId *uuid.UUID) *models.KTSError
-	RemoveAllGenreCombinationWithMovie(movieId *uuid.UUID) *models.KTSError
-	RemoveAllMovieCombinationWithGenre(genreId *uuid.UUID) *models.KTSError
+	AddMovieGenre(movieId *myid.UUID, genreId *myid.UUID) *models.KTSError
+	RemoveMovieGenre(movieId *myid.UUID, genreId *myid.UUID) *models.KTSError
+	RemoveAllGenreCombinationWithMovie(movieId *myid.UUID) *models.KTSError
+	RemoveAllMovieCombinationWithGenre(genreId *myid.UUID) *models.KTSError
 }
 
 type MovieGenreRepository struct {
@@ -22,10 +22,10 @@ type MovieGenreRepository struct {
 }
 
 // Combine Movie and Genre
-func (mgr *MovieGenreRepository) AddMovieGenre(movieId *uuid.UUID, genreId *uuid.UUID) *models.KTSError {
+func (mgr *MovieGenreRepository) AddMovieGenre(movieId *myid.UUID, genreId *myid.UUID) *models.KTSError {
 	// Create the insert statement
 	insertQuery := table.MovieGenres.INSERT(table.MovieGenres.MovieID, table.MovieGenres.GenreID).
-		VALUES(utils.MysqlUuid(movieId), utils.MysqlUuid(genreId))
+		VALUES(utils.MysqlUuid(*movieId), utils.MysqlUuid(*genreId))
 
 	// Execute the query
 	rows, err := insertQuery.Exec(mgr.DatabaseManager.GetDatabaseConnection())
@@ -45,11 +45,11 @@ func (mgr *MovieGenreRepository) AddMovieGenre(movieId *uuid.UUID, genreId *uuid
 	return nil
 }
 
-func (mgr *MovieGenreRepository) RemoveMovieGenre(movieId *uuid.UUID, genreId *uuid.UUID) *models.KTSError {
+func (mgr *MovieGenreRepository) RemoveMovieGenre(movieId *myid.UUID, genreId *myid.UUID) *models.KTSError {
 
 	deleteQuery := table.MovieGenres.DELETE().WHERE(
-		table.MovieGenres.MovieID.EQ(utils.MysqlUuid(movieId)).AND(
-			table.MovieGenres.GenreID.EQ(utils.MysqlUuid(genreId)),
+		table.MovieGenres.MovieID.EQ(utils.MysqlUuid(*movieId)).AND(
+			table.MovieGenres.GenreID.EQ(utils.MysqlUuid(*genreId)),
 		),
 	)
 
@@ -71,9 +71,9 @@ func (mgr *MovieGenreRepository) RemoveMovieGenre(movieId *uuid.UUID, genreId *u
 	return nil
 }
 
-func (mgr *MovieGenreRepository) RemoveAllGenreCombinationWithMovie(movieId *uuid.UUID) *models.KTSError {
+func (mgr *MovieGenreRepository) RemoveAllGenreCombinationWithMovie(movieId *myid.UUID) *models.KTSError {
 	deleteQuery := table.MovieGenres.DELETE().WHERE(
-		table.MovieGenres.MovieID.EQ(utils.MysqlUuid(movieId)),
+		table.MovieGenres.MovieID.EQ(utils.MysqlUuid(*movieId)),
 	)
 
 	// Execute the query
@@ -86,9 +86,9 @@ func (mgr *MovieGenreRepository) RemoveAllGenreCombinationWithMovie(movieId *uui
 
 }
 
-func (mgr *MovieGenreRepository) RemoveAllMovieCombinationWithGenre(genreId *uuid.UUID) *models.KTSError {
+func (mgr *MovieGenreRepository) RemoveAllMovieCombinationWithGenre(genreId *myid.UUID) *models.KTSError {
 	deleteQuery := table.MovieGenres.DELETE().WHERE(
-		table.MovieGenres.GenreID.EQ(utils.MysqlUuid(genreId)),
+		table.MovieGenres.GenreID.EQ(utils.MysqlUuid(*genreId)),
 	)
 
 	// Execute the query

--- a/src/repositories/movie_genres_repository_test.go
+++ b/src/repositories/movie_genres_repository_test.go
@@ -8,42 +8,42 @@ import (
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/managers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
 // AddMovieGenre
 func TestAddMovieGenre(t *testing.T) {
 
-	uuid1 := uuid.New()
-	uuid2 := uuid.New()
+	uuid1 := myid.New()
+	uuid2 := myid.New()
 
 	query := "INSERT INTO `KinoTicketSystem`.movie_genres (movie_id, genre_id) VALUES (?, ?);\n"
 
 	testCases := []struct {
 		name            string
-		setExpectations func(mock sqlmock.Sqlmock, movieId *uuid.UUID, genreId *uuid.UUID)
+		setExpectations func(mock sqlmock.Sqlmock, movieId *myid.UUID, genreId *myid.UUID)
 		expectedError   *models.KTSError
 	}{
 		{
 			name: "Create movieGenre",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID, genreId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&uuid1), utils.EqUUID(&uuid2)).WillReturnResult(sqlmock.NewResult(1, 1))
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID, genreId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(uuid1), utils.EqUUID(uuid2)).WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 			expectedError: nil,
 		},
 		{
 			name: "Error while creating movieGenre",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID, genreId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&uuid1), utils.EqUUID(&uuid2)).WillReturnError(sqlmock.ErrCancelled)
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID, genreId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(uuid1), utils.EqUUID(uuid2)).WillReturnError(sqlmock.ErrCancelled)
 			},
 			expectedError: kts_errors.KTS_INTERNAL_ERROR,
 		},
 		{
 			name: "Error while converting rows affected",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID, genreId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&uuid1), utils.EqUUID(&uuid2)).WillReturnResult(
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID, genreId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(uuid1), utils.EqUUID(uuid2)).WillReturnResult(
 					sqlmock.NewErrorResult(errors.New("rows affected conversion did not work")),
 				)
 			},
@@ -51,8 +51,8 @@ func TestAddMovieGenre(t *testing.T) {
 		},
 		{
 			name: "movieGenre not found",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID, genreId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&uuid1), utils.EqUUID(&uuid2)).WillReturnResult(sqlmock.NewResult(1, 0))
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID, genreId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(uuid1), utils.EqUUID(uuid2)).WillReturnResult(sqlmock.NewResult(1, 0))
 			},
 			expectedError: kts_errors.KTS_NOT_FOUND,
 		},
@@ -95,34 +95,34 @@ func TestAddMovieGenre(t *testing.T) {
 
 func TestRemoveMovieGenre(t *testing.T) {
 
-	uuid1 := uuid.New()
-	uuid2 := uuid.New()
+	uuid1 := myid.New()
+	uuid2 := myid.New()
 
 	query := "DELETE FROM `KinoTicketSystem`.movie_genres\nWHERE (movie_genres.movie_id = ?) AND (movie_genres.genre_id = ?);\n"
 
 	testCases := []struct {
 		name            string
-		setExpectations func(mock sqlmock.Sqlmock, movieId *uuid.UUID, genreId *uuid.UUID)
+		setExpectations func(mock sqlmock.Sqlmock, movieId *myid.UUID, genreId *myid.UUID)
 		expectedError   *models.KTSError
 	}{
 		{
 			name: "Add movie_genre",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID, genreId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&uuid1), utils.EqUUID(&uuid2)).WillReturnResult(sqlmock.NewResult(1, 1))
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID, genreId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(uuid1), utils.EqUUID(uuid2)).WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 			expectedError: nil,
 		},
 		{
 			name: "Error while adding movie_genre",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID, genreId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&uuid1), utils.EqUUID(&uuid2)).WillReturnError(sqlmock.ErrCancelled)
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID, genreId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(uuid1), utils.EqUUID(uuid2)).WillReturnError(sqlmock.ErrCancelled)
 			},
 			expectedError: kts_errors.KTS_INTERNAL_ERROR,
 		},
 		{
 			name: "Error while converting rows affected",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID, genreId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&uuid1), utils.EqUUID(&uuid2)).WillReturnResult(
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID, genreId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(uuid1), utils.EqUUID(uuid2)).WillReturnResult(
 					sqlmock.NewErrorResult(errors.New("rows affected conversion did not work")),
 				)
 			},
@@ -130,8 +130,8 @@ func TestRemoveMovieGenre(t *testing.T) {
 		},
 		{
 			name: "Movie not found",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID, genreId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&uuid1), utils.EqUUID(&uuid2)).WillReturnResult(sqlmock.NewResult(1, 0))
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID, genreId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(uuid1), utils.EqUUID(uuid2)).WillReturnResult(sqlmock.NewResult(1, 0))
 			},
 			expectedError: kts_errors.KTS_NOT_FOUND,
 		},
@@ -172,26 +172,26 @@ func TestRemoveMovieGenre(t *testing.T) {
 
 func TestRemoveAllGenreCombinationWithMovie(t *testing.T) {
 
-	movieId := uuid.New()
+	movieId := myid.New()
 
 	query := "DELETE FROM `KinoTicketSystem`.movie_genres WHERE movie_genres.movie_id = ?;"
 
 	testCases := []struct {
 		name            string
-		setExpectations func(mock sqlmock.Sqlmock, movieId *uuid.UUID)
+		setExpectations func(mock sqlmock.Sqlmock, movieId *myid.UUID)
 		expectedError   *models.KTSError
 	}{
 		{
 			name: "Remove all genre corresponding to one movie",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(movieId)).WillReturnResult(sqlmock.NewResult(1, 1))
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(*movieId)).WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 			expectedError: nil,
 		},
 		{
 			name: "Error while removing movie_genres",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(movieId)).WillReturnError(sqlmock.ErrCancelled)
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(*movieId)).WillReturnError(sqlmock.ErrCancelled)
 			},
 			expectedError: kts_errors.KTS_INTERNAL_ERROR,
 		},
@@ -232,26 +232,26 @@ func TestRemoveAllGenreCombinationWithMovie(t *testing.T) {
 
 func TestRemoveAllMovieCombinationWithGenre(t *testing.T) {
 
-	genreId := uuid.New()
+	genreId := myid.New()
 
 	query := "DELETE FROM `KinoTicketSystem`.movie_genres WHERE movie_genres.genre_id = ?;"
 
 	testCases := []struct {
 		name            string
-		setExpectations func(mock sqlmock.Sqlmock, genreId *uuid.UUID)
+		setExpectations func(mock sqlmock.Sqlmock, genreId *myid.UUID)
 		expectedError   *models.KTSError
 	}{
 		{
 			name: "Remove all movies corresponding to one genre",
-			setExpectations: func(mock sqlmock.Sqlmock, genreId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(genreId)).WillReturnResult(sqlmock.NewResult(1, 1))
+			setExpectations: func(mock sqlmock.Sqlmock, genreId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(*genreId)).WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 			expectedError: nil,
 		},
 		{
 			name: "Error while removing movie_genre",
-			setExpectations: func(mock sqlmock.Sqlmock, genreId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(genreId)).WillReturnError(sqlmock.ErrCancelled)
+			setExpectations: func(mock sqlmock.Sqlmock, genreId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(*genreId)).WillReturnError(sqlmock.ErrCancelled)
 			},
 			expectedError: kts_errors.KTS_INTERNAL_ERROR,
 		},

--- a/src/repositories/movie_producer_repository.go
+++ b/src/repositories/movie_producer_repository.go
@@ -5,15 +5,15 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/table"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/managers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
 )
 
 type MovieProducerRepositoryI interface {
 	// Combine Movie and Actor
-	AddMovieProducer(movieId *uuid.UUID, producerId *uuid.UUID) *models.KTSError
-	RemoveMovieProducer(movieId *uuid.UUID, producerId *uuid.UUID) *models.KTSError
-	RemoveAllProducerCombinationWithMovie(movieId *uuid.UUID) *models.KTSError
+	AddMovieProducer(movieId *myid.UUID, producerId *myid.UUID) *models.KTSError
+	RemoveMovieProducer(movieId *myid.UUID, producerId *myid.UUID) *models.KTSError
+	RemoveAllProducerCombinationWithMovie(movieId *myid.UUID) *models.KTSError
 }
 
 type MovieProducerRepository struct {
@@ -21,11 +21,11 @@ type MovieProducerRepository struct {
 }
 
 // Combine Movie and Genre
-func (pr *MovieProducerRepository) AddMovieProducer(movieId *uuid.UUID, producerId *uuid.UUID) *models.KTSError {
+func (pr *MovieProducerRepository) AddMovieProducer(movieId *myid.UUID, producerId *myid.UUID) *models.KTSError {
 
 	// Create the insert statement
 	insertQuery := table.MovieProducers.INSERT(table.MovieProducers.MovieID, table.MovieProducers.ProducerID).
-		VALUES(utils.MysqlUuid(movieId), utils.MysqlUuid(producerId))
+		VALUES(utils.MysqlUuid(*movieId), utils.MysqlUuid(*producerId))
 
 	// Execute the query
 	rows, err := insertQuery.Exec(pr.DatabaseManager.GetDatabaseConnection())
@@ -45,11 +45,11 @@ func (pr *MovieProducerRepository) AddMovieProducer(movieId *uuid.UUID, producer
 	return nil
 }
 
-func (pr *MovieProducerRepository) RemoveMovieProducer(movieId *uuid.UUID, producerId *uuid.UUID) *models.KTSError {
+func (pr *MovieProducerRepository) RemoveMovieProducer(movieId *myid.UUID, producerId *myid.UUID) *models.KTSError {
 
 	deleteQuery := table.MovieProducers.DELETE().WHERE(
-		table.MovieProducers.MovieID.EQ(utils.MysqlUuid(movieId)).AND(
-			table.MovieProducers.ProducerID.EQ(utils.MysqlUuid(producerId)),
+		table.MovieProducers.MovieID.EQ(utils.MysqlUuid(*movieId)).AND(
+			table.MovieProducers.ProducerID.EQ(utils.MysqlUuid(*producerId)),
 		),
 	)
 
@@ -71,9 +71,9 @@ func (pr *MovieProducerRepository) RemoveMovieProducer(movieId *uuid.UUID, produ
 	return nil
 }
 
-func (pr *MovieProducerRepository) RemoveAllProducerCombinationWithMovie(movieId *uuid.UUID) *models.KTSError {
+func (pr *MovieProducerRepository) RemoveAllProducerCombinationWithMovie(movieId *myid.UUID) *models.KTSError {
 	deleteQuery := table.MovieProducers.DELETE().WHERE(
-		table.MovieProducers.MovieID.EQ(utils.MysqlUuid(movieId)),
+		table.MovieProducers.MovieID.EQ(utils.MysqlUuid(*movieId)),
 	)
 
 	// Execute the query
@@ -81,8 +81,6 @@ func (pr *MovieProducerRepository) RemoveAllProducerCombinationWithMovie(movieId
 	if err != nil {
 		return kts_errors.KTS_INTERNAL_ERROR
 	}
-
-
 
 	return nil
 }

--- a/src/repositories/movie_producer_repository_test.go
+++ b/src/repositories/movie_producer_repository_test.go
@@ -8,41 +8,41 @@ import (
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/managers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAddMovieProducer(t *testing.T) {
 
-	uuid1 := uuid.New()
-	uuid2 := uuid.New()
+	uuid1 := myid.New()
+	uuid2 := myid.New()
 
 	query := "INSERT INTO `KinoTicketSystem`.movie_producers (movie_id, producer_id) VALUES (?, ?);"
 
 	testCases := []struct {
 		name            string
-		setExpectations func(mock sqlmock.Sqlmock, movieId *uuid.UUID, producerId *uuid.UUID)
+		setExpectations func(mock sqlmock.Sqlmock, movieId *myid.UUID, producerId *myid.UUID)
 		expectedError   *models.KTSError
 	}{
 		{
 			name: "Create movieProducer",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID, producerId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&uuid1), utils.EqUUID(&uuid2)).WillReturnResult(sqlmock.NewResult(1, 1))
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID, producerId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(uuid1), utils.EqUUID(uuid2)).WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 			expectedError: nil,
 		},
 		{
 			name: "Error while creating movieProducer",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID, producerId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&uuid1), utils.EqUUID(&uuid2)).WillReturnError(sqlmock.ErrCancelled)
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID, producerId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(uuid1), utils.EqUUID(uuid2)).WillReturnError(sqlmock.ErrCancelled)
 			},
 			expectedError: kts_errors.KTS_INTERNAL_ERROR,
 		},
 		{
 			name: "Error while converting rows affected",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID, producerId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&uuid1), utils.EqUUID(&uuid2)).WillReturnResult(
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID, producerId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(uuid1), utils.EqUUID(uuid2)).WillReturnResult(
 					sqlmock.NewErrorResult(errors.New("rows affected conversion did not work")),
 				)
 			},
@@ -50,8 +50,8 @@ func TestAddMovieProducer(t *testing.T) {
 		},
 		{
 			name: "movieProducer not found",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID, producerId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&uuid1), utils.EqUUID(&uuid2)).WillReturnResult(sqlmock.NewResult(1, 0))
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID, producerId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(uuid1), utils.EqUUID(uuid2)).WillReturnResult(sqlmock.NewResult(1, 0))
 			},
 			expectedError: kts_errors.KTS_NOT_FOUND,
 		},
@@ -94,34 +94,34 @@ func TestAddMovieProducer(t *testing.T) {
 
 func TestRemoveMovieProducer(t *testing.T) {
 
-	uuid1 := uuid.New()
-	uuid2 := uuid.New()
+	uuid1 := myid.New()
+	uuid2 := myid.New()
 
 	query := "DELETE FROM `KinoTicketSystem`.movie_producers WHERE (movie_producers.movie_id = ?) AND (movie_producers.producer_id = ?);"
 
 	testCases := []struct {
 		name            string
-		setExpectations func(mock sqlmock.Sqlmock, movieId *uuid.UUID, producerId *uuid.UUID)
+		setExpectations func(mock sqlmock.Sqlmock, movieId *myid.UUID, producerId *myid.UUID)
 		expectedError   *models.KTSError
 	}{
 		{
 			name: "Add movie_producer",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID, producerId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&uuid1), utils.EqUUID(&uuid2)).WillReturnResult(sqlmock.NewResult(1, 1))
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID, producerId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(uuid1), utils.EqUUID(uuid2)).WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 			expectedError: nil,
 		},
 		{
 			name: "Error while adding movie_producer",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID, producerId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&uuid1), utils.EqUUID(&uuid2)).WillReturnError(sqlmock.ErrCancelled)
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID, producerId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(uuid1), utils.EqUUID(uuid2)).WillReturnError(sqlmock.ErrCancelled)
 			},
 			expectedError: kts_errors.KTS_INTERNAL_ERROR,
 		},
 		{
 			name: "Error while converting rows affected",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID, producerId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&uuid1), utils.EqUUID(&uuid2)).WillReturnResult(
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID, producerId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(uuid1), utils.EqUUID(uuid2)).WillReturnResult(
 					sqlmock.NewErrorResult(errors.New("rows affected conversion did not work")),
 				)
 			},
@@ -129,8 +129,8 @@ func TestRemoveMovieProducer(t *testing.T) {
 		},
 		{
 			name: "MovieProducer not found",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID, producerId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(&uuid1), utils.EqUUID(&uuid2)).WillReturnResult(sqlmock.NewResult(1, 0))
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID, producerId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(uuid1), utils.EqUUID(uuid2)).WillReturnResult(sqlmock.NewResult(1, 0))
 			},
 			expectedError: kts_errors.KTS_NOT_FOUND,
 		},
@@ -169,30 +169,28 @@ func TestRemoveMovieProducer(t *testing.T) {
 	}
 }
 
-
-
 func TestRemoveAllProducerCombinationWithMovie(t *testing.T) {
 
-	movieId := uuid.New()
+	movieId := myid.New()
 
 	query := "DELETE FROM `KinoTicketSystem`.movie_producers WHERE movie_producers.movie_id = ?;"
 
 	testCases := []struct {
 		name            string
-		setExpectations func(mock sqlmock.Sqlmock, movieId *uuid.UUID)
+		setExpectations func(mock sqlmock.Sqlmock, movieId *myid.UUID)
 		expectedError   *models.KTSError
 	}{
 		{
 			name: "Remove all actors corresponding to one movie",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(movieId)).WillReturnResult(sqlmock.NewResult(1, 1))
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(*movieId)).WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 			expectedError: nil,
 		},
 		{
 			name: "Error while removing movie_actor",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(movieId)).WillReturnError(sqlmock.ErrCancelled)
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(*movieId)).WillReturnError(sqlmock.ErrCancelled)
 			},
 			expectedError: kts_errors.KTS_INTERNAL_ERROR,
 		},

--- a/src/repositories/movie_repository_test.go
+++ b/src/repositories/movie_repository_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/managers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/samples"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -338,33 +338,33 @@ func TestUpdateMovie(t *testing.T) {
 
 // Delete Movie
 func TestDeleteMovie(t *testing.T) {
-	movieId := uuid.New()
+	movieId := myid.New()
 
 	query := "DELETE FROM `KinoTicketSystem`.movies WHERE movies.id = ?;"
 
 	testCases := []struct {
 		name            string
-		setExpectations func(mock sqlmock.Sqlmock, movieId *uuid.UUID)
+		setExpectations func(mock sqlmock.Sqlmock, movieId *myid.UUID)
 		expectedError   *models.KTSError
 	}{
 		{
 			name: "Delete movie",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(movieId)).WillReturnResult(sqlmock.NewResult(1, 1))
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(*movieId)).WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 			expectedError: nil,
 		},
 		{
 			name: "Error while deleting movie",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(movieId)).WillReturnError(sqlmock.ErrCancelled)
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(*movieId)).WillReturnError(sqlmock.ErrCancelled)
 			},
 			expectedError: kts_errors.KTS_INTERNAL_ERROR,
 		},
 		{
 			name: "Error while converting rows affected",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(movieId)).WillReturnResult(
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(*movieId)).WillReturnResult(
 					sqlmock.NewErrorResult(errors.New("rows affected conversion did not work")),
 				)
 			},
@@ -372,8 +372,8 @@ func TestDeleteMovie(t *testing.T) {
 		},
 		{
 			name: "Movie not found",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(utils.EqUUID(movieId)).WillReturnResult(sqlmock.NewResult(1, 0))
+			setExpectations: func(mock sqlmock.Sqlmock, movieId *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(utils.EqUUID(*movieId)).WillReturnResult(sqlmock.NewResult(1, 0))
 			},
 			expectedError: kts_errors.KTS_NOT_FOUND,
 		},
@@ -499,20 +499,20 @@ func TestGetMoviesWithGenres(t *testing.T) {
 func TestGetMovieById(t *testing.T) {
 	smplFullMovie := samples.GetSampleMovieByIdWithEverything()
 
-	id := smplFullMovie.ID
+	id := &smplFullMovie.ID
 
 	query := "SELECT movies.id AS \"movies.id\", movies.title AS \"movies.title\", movies.description AS \"movies.description\", movies.banner_pic_url AS \"movies.banner_pic_url\", movies.cover_pic_url AS \"movies.cover_pic_url\", movies.trailer_url AS \"movies.trailer_url\", movies.rating AS \"movies.rating\", movies.release_date AS \"movies.release_date\", movies.time_in_min AS \"movies.time_in_min\", movies.fsk AS \"movies.fsk\", genres.id AS \"genres.id\", genres.genre_name AS \"genres.genre_name\", actors.id AS \"actors.id\", actors.name AS \"actors.name\", actors.birthdate AS \"actors.birthdate\", actors.description AS \"actors.description\", producers.id AS \"producers.id\", producers.name AS \"producers.name\", producers.birthdate AS \"producers.birthdate\", producers.description AS \"producers.description\", reviews.id AS \"reviews.id\", reviews.rating AS \"reviews.rating\", reviews.comment AS \"reviews.comment\", reviews.datetime AS \"reviews.datetime\", reviews.is_spoiler AS \"reviews.is_spoiler\", reviews.user_id AS \"reviews.user_id\", reviews.movie_id AS \"reviews.movie_id\", users.username AS \"users.username\" FROM `KinoTicketSystem`.movies LEFT JOIN `KinoTicketSystem`.movie_genres ON (movie_genres.movie_id = movies.id) LEFT JOIN `KinoTicketSystem`.genres ON (genres.id = movie_genres.genre_id) LEFT JOIN `KinoTicketSystem`.movie_actors ON (movie_actors.movie_id = movies.id) LEFT JOIN `KinoTicketSystem`.actors ON (actors.id = movie_actors.actor_id) LEFT JOIN `KinoTicketSystem`.movie_producers ON (movie_producers.movie_id = movies.id) LEFT JOIN `KinoTicketSystem`.producers ON (producers.id = movie_producers.producer_id) LEFT JOIN `KinoTicketSystem`.reviews ON (reviews.movie_id = movies.id) LEFT JOIN `KinoTicketSystem`.users ON (users.id = reviews.user_id) WHERE movies.id = ?;"
 
 	testCases := []struct {
 		name            string
-		setExpectations func(mock sqlmock.Sqlmock, id *uuid.UUID)
+		setExpectations func(mock sqlmock.Sqlmock, id *myid.UUID)
 		expectedMovie   *models.MovieWithEverything
 		expectedError   *models.KTSError
 	}{
 		{
 			name: "Empty result",
-			setExpectations: func(mock sqlmock.Sqlmock, id *uuid.UUID) {
-				mock.ExpectQuery(query).WithArgs(utils.EqUUID(id)).WillReturnRows(
+			setExpectations: func(mock sqlmock.Sqlmock, id *myid.UUID) {
+				mock.ExpectQuery(query).WithArgs(utils.EqUUID(*id)).WillReturnRows(
 					sqlmock.NewRows([]string{"movies.id", "movies.title", "movies.description", "movies.banner_pic_url", "movies.cover_pic_url", "movies.trailer_url", "movies.rating", "movies.release_date", "movies.time_in_min", "movies.fsk", "genres.id", "genres.genre_name", "actors.id", "actors.name", "actors.birthdate", "actors.description", "producers.id", "producers.name", "producers.birthdate", "producers.description", "reviews.id", "reviews.rating", "reviews.comment", "reviews.datetime", "reviews.is_spoiler", "reviews.user_id", "reviews.movie_id", "users.username"}),
 				)
 			},
@@ -521,8 +521,8 @@ func TestGetMovieById(t *testing.T) {
 		},
 		{
 			name: "Single movie",
-			setExpectations: func(mock sqlmock.Sqlmock, id *uuid.UUID) {
-				mock.ExpectQuery(query).WithArgs(utils.EqUUID(id)).WillReturnRows(
+			setExpectations: func(mock sqlmock.Sqlmock, id *myid.UUID) {
+				mock.ExpectQuery(query).WithArgs(utils.EqUUID(*id)).WillReturnRows(
 					sqlmock.NewRows(
 						[]string{"movies.id", "movies.title", "movies.description", "movies.banner_pic_url", "movies.cover_pic_url", "movies.trailer_url", "movies.rating", "movies.release_date", "movies.time_in_min", "movies.fsk", "genres.id", "genres.genre_name", "actors.id", "actors.name", "actors.birthdate", "actors.description", "producers.id", "producers.name", "producers.birthdate", "producers.description", "reviews.id", "reviews.rating", "reviews.comment", "reviews.datetime", "reviews.is_spoiler", "reviews.user_id", "reviews.movie_id", "users.username"},
 					).AddRow(
@@ -535,8 +535,8 @@ func TestGetMovieById(t *testing.T) {
 		},
 		{
 			name: "Error while querying movies",
-			setExpectations: func(mock sqlmock.Sqlmock, id *uuid.UUID) {
-				mock.ExpectQuery(query).WithArgs(utils.EqUUID(id)).WillReturnError(sqlmock.ErrCancelled)
+			setExpectations: func(mock sqlmock.Sqlmock, id *myid.UUID) {
+				mock.ExpectQuery(query).WithArgs(utils.EqUUID(*id)).WillReturnError(sqlmock.ErrCancelled)
 			},
 			expectedMovie: nil,
 			expectedError: kts_errors.KTS_INTERNAL_ERROR,

--- a/src/repositories/order_repository_test.go
+++ b/src/repositories/order_repository_test.go
@@ -8,8 +8,8 @@ import (
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/managers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/samples"
-	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -138,7 +138,7 @@ func TestGetOrderById(t *testing.T) {
 
 			tc.setExpectations(mock)
 
-			order, kts_err := orderRepo.GetOrderById(utils.NewUUID(), utils.NewUUID())
+			order, kts_err := orderRepo.GetOrderById(myid.NewUUID(), myid.NewUUID())
 
 			if kts_err != tc.expectedError {
 				t.Errorf("Unexpected error: %v", kts_err)
@@ -203,7 +203,7 @@ func TestGetOrders(t *testing.T) {
 
 			tc.setExpectations(mock)
 
-			orders, kts_err := orderRepo.GetOrders(utils.NewUUID())
+			orders, kts_err := orderRepo.GetOrders(myid.NewUUID())
 
 			if kts_err != tc.expectedError {
 				t.Errorf("Unexpected error: %v", kts_err)

--- a/src/repositories/price_category_repository.go
+++ b/src/repositories/price_category_repository.go
@@ -5,8 +5,8 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/table"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/managers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
 
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 
@@ -15,10 +15,10 @@ import (
 
 type PriceCategoryRepositoryI interface {
 	GetPriceCategories() (*[]model.PriceCategories, *models.KTSError)
-	GetPriceCategoryById(id *uuid.UUID) (*model.PriceCategories, *models.KTSError)
-	CreatePriceCategory(priceCategory *model.PriceCategories) (*uuid.UUID, *models.KTSError)
-	UpdatePriceCategory(priceCategory *model.PriceCategories) (*uuid.UUID, *models.KTSError)
-	DeletePriceCategory(id *uuid.UUID) *models.KTSError
+	GetPriceCategoryById(id *myid.UUID) (*model.PriceCategories, *models.KTSError)
+	CreatePriceCategory(priceCategory *model.PriceCategories) (*myid.UUID, *models.KTSError)
+	UpdatePriceCategory(priceCategory *model.PriceCategories) (*myid.UUID, *models.KTSError)
+	DeletePriceCategory(id *myid.UUID) *models.KTSError
 }
 
 type PriceCategoryRepository struct {
@@ -48,7 +48,7 @@ func (pcr *PriceCategoryRepository) GetPriceCategories() (*[]model.PriceCategori
 	return &priceCategory, nil
 }
 
-func (pcr *PriceCategoryRepository) GetPriceCategoryById(id *uuid.UUID) (*model.PriceCategories, *models.KTSError) {
+func (pcr *PriceCategoryRepository) GetPriceCategoryById(id *myid.UUID) (*model.PriceCategories, *models.KTSError) {
 	var priceCategory model.PriceCategories
 
 	// Create the query
@@ -57,7 +57,7 @@ func (pcr *PriceCategoryRepository) GetPriceCategoryById(id *uuid.UUID) (*model.
 	).FROM(
 		table.PriceCategories,
 	).WHERE(
-		table.PriceCategories.ID.EQ(utils.MysqlUuid(id)),
+		table.PriceCategories.ID.EQ(utils.MysqlUuid(*id)),
 	)
 
 	// Execute the query
@@ -72,13 +72,13 @@ func (pcr *PriceCategoryRepository) GetPriceCategoryById(id *uuid.UUID) (*model.
 	return &priceCategory, nil
 }
 
-func (pcr *PriceCategoryRepository) CreatePriceCategory(priceCategory *model.PriceCategories) (*uuid.UUID, *models.KTSError) {
-	priceCategory.ID = utils.NewUUID()
+func (pcr *PriceCategoryRepository) CreatePriceCategory(priceCategory *model.PriceCategories) (*myid.UUID, *models.KTSError) {
+	priceCategory.ID = myid.New()
 	// Create the query
 	stmt := table.PriceCategories.INSERT(
 		table.PriceCategories.AllColumns,
 	).VALUES(
-		utils.MysqlUuid(priceCategory.ID),
+		priceCategory.ID,
 		priceCategory.CategoryName,
 		priceCategory.Price,
 	)
@@ -98,15 +98,15 @@ func (pcr *PriceCategoryRepository) CreatePriceCategory(priceCategory *model.Pri
 		return nil, kts_errors.KTS_NOT_FOUND
 	}
 
-	return priceCategory.ID, nil
+	return &priceCategory.ID, nil
 }
 
-func (pcr *PriceCategoryRepository) UpdatePriceCategory(priceCategory *model.PriceCategories) (*uuid.UUID, *models.KTSError) {
+func (pcr *PriceCategoryRepository) UpdatePriceCategory(priceCategory *model.PriceCategories) (*myid.UUID, *models.KTSError) {
 	// Create the query
 	stmt := table.PriceCategories.UPDATE(
 		table.PriceCategories.AllColumns,
 	).SET(
-		utils.MysqlUuid(priceCategory.ID),
+		priceCategory.ID,
 		priceCategory.CategoryName,
 		priceCategory.Price,
 	).WHERE(
@@ -128,12 +128,12 @@ func (pcr *PriceCategoryRepository) UpdatePriceCategory(priceCategory *model.Pri
 		return nil, kts_errors.KTS_NOT_FOUND
 	}
 
-	return priceCategory.ID, nil
+	return &priceCategory.ID, nil
 }
 
-func (pcr *PriceCategoryRepository) DeletePriceCategory(id *uuid.UUID) *models.KTSError {
+func (pcr *PriceCategoryRepository) DeletePriceCategory(id *myid.UUID) *models.KTSError {
 	// Create the query
-	stmt := table.PriceCategories.DELETE().WHERE(table.PriceCategories.ID.EQ(utils.MysqlUuid(id)))
+	stmt := table.PriceCategories.DELETE().WHERE(table.PriceCategories.ID.EQ(utils.MysqlUuid(*id)))
 
 	// Execute the query
 	rows, err := stmt.Exec(pcr.DatabaseManager.GetDatabaseConnection())

--- a/src/repositories/price_category_repository_test.go
+++ b/src/repositories/price_category_repository_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/managers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/samples"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -108,13 +108,13 @@ func TestGetPriceCategoryById(t *testing.T) {
 
 	testCases := []struct {
 		name                    string
-		setExpectations         func(mock sqlmock.Sqlmock, id *uuid.UUID)
+		setExpectations         func(mock sqlmock.Sqlmock)
 		expectedpricecategories *model.PriceCategories
 		expectedError           *models.KTSError
 	}{
 		{
 			name: "PriceCategory found",
-			setExpectations: func(mock sqlmock.Sqlmock, id *uuid.UUID) {
+			setExpectations: func(mock sqlmock.Sqlmock) {
 				mock.ExpectQuery(query).WithArgs(utils.EqUUID(priceCategoryId)).WillReturnRows(
 					sqlmock.NewRows(
 						[]string{"price_categories.id", "price_categories.category_name", "price_categories.price"},
@@ -128,7 +128,7 @@ func TestGetPriceCategoryById(t *testing.T) {
 		},
 		{
 			name: "PriceCategory not found",
-			setExpectations: func(mock sqlmock.Sqlmock, id *uuid.UUID) {
+			setExpectations: func(mock sqlmock.Sqlmock) {
 				mock.ExpectQuery(query).WithArgs(utils.EqUUID(priceCategoryId)).WillReturnRows(
 					sqlmock.NewRows([]string{"price_categories.id", "price_categories.category_name", "price_categories.price"}),
 				)
@@ -138,7 +138,7 @@ func TestGetPriceCategoryById(t *testing.T) {
 		},
 		{
 			name: "Error while querying PriceCategory",
-			setExpectations: func(mock sqlmock.Sqlmock, id *uuid.UUID) {
+			setExpectations: func(mock sqlmock.Sqlmock) {
 				mock.ExpectQuery(query).WithArgs(utils.EqUUID(priceCategoryId)).WillReturnError(sqlmock.ErrCancelled)
 			},
 			expectedpricecategories: nil,
@@ -163,11 +163,11 @@ func TestGetPriceCategoryById(t *testing.T) {
 				},
 			}
 
-			tc.setExpectations(mock, priceCategoryId)
+			tc.setExpectations(mock)
 
 			// WHEN
 			// Call the method under test
-			priceCategory, kts_err := priceCategoryRepo.GetPriceCategoryById(priceCategoryId)
+			priceCategory, kts_err := priceCategoryRepo.GetPriceCategoryById(&priceCategoryId)
 
 			// THEN
 			// Verify the results
@@ -357,26 +357,26 @@ func TestDeletePriceCategory(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		setExpectations func(mock sqlmock.Sqlmock, id *uuid.UUID)
+		setExpectations func(mock sqlmock.Sqlmock, id myid.UUID)
 		expectedError   *models.KTSError
 	}{
 		{
 			name: "PriceCategory deleted",
-			setExpectations: func(mock sqlmock.Sqlmock, id *uuid.UUID) {
+			setExpectations: func(mock sqlmock.Sqlmock, id myid.UUID) {
 				mock.ExpectExec(query).WithArgs(utils.EqUUID(id)).WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 			expectedError: nil,
 		},
 		{
 			name: "Error while deleting PriceCategory",
-			setExpectations: func(mock sqlmock.Sqlmock, id *uuid.UUID) {
+			setExpectations: func(mock sqlmock.Sqlmock, id myid.UUID) {
 				mock.ExpectExec(query).WithArgs(utils.EqUUID(id)).WillReturnError(sqlmock.ErrCancelled)
 			},
 			expectedError: kts_errors.KTS_INTERNAL_ERROR,
 		},
 		{
 			name: "Error while converting rows affected",
-			setExpectations: func(mock sqlmock.Sqlmock, id *uuid.UUID) {
+			setExpectations: func(mock sqlmock.Sqlmock, id myid.UUID) {
 				mock.ExpectExec(query).WithArgs(utils.EqUUID(id)).WillReturnResult(
 					sqlmock.NewErrorResult(errors.New("rows affected conversion did not work")),
 				)
@@ -385,7 +385,7 @@ func TestDeletePriceCategory(t *testing.T) {
 		},
 		{
 			name: "PriceCategory not found",
-			setExpectations: func(mock sqlmock.Sqlmock, id *uuid.UUID) {
+			setExpectations: func(mock sqlmock.Sqlmock, id myid.UUID) {
 				mock.ExpectExec(query).WithArgs(utils.EqUUID(id)).WillReturnResult(sqlmock.NewResult(1, 0))
 			},
 			expectedError: kts_errors.KTS_NOT_FOUND,
@@ -413,7 +413,7 @@ func TestDeletePriceCategory(t *testing.T) {
 
 			// WHEN
 			// Call the method under test
-			kts_err := priceCategoryRepo.DeletePriceCategory(priceCategoryId)
+			kts_err := priceCategoryRepo.DeletePriceCategory(&priceCategoryId)
 
 			// THEN
 			// Verify the results

--- a/src/repositories/review_repository.go
+++ b/src/repositories/review_repository.go
@@ -8,15 +8,15 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/table"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/managers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
 )
 
 type ReviewRepositoryI interface {
 	CreateReview(review model.Reviews) *models.KTSError
-	GetReviewById(id *uuid.UUID) (*model.Reviews, *models.KTSError)
-	DeleteReview(id *uuid.UUID) *models.KTSError
-	DeleteReviewForMovie(movieId *uuid.UUID) *models.KTSError
+	GetReviewById(id *myid.UUID) (*model.Reviews, *models.KTSError)
+	DeleteReview(id *myid.UUID) *models.KTSError
+	DeleteReviewForMovie(movieId *myid.UUID) *models.KTSError
 }
 
 type ReviewRepository struct {
@@ -33,13 +33,13 @@ func (rr *ReviewRepository) CreateReview(review model.Reviews) *models.KTSError 
 		table.Reviews.UserID,
 		table.Reviews.MovieID,
 	).VALUES(
-		utils.MysqlUuid(review.ID),
+		review.ID,
 		review.Rating,
 		review.Comment,
 		review.Datetime,
 		review.IsSpoiler != nil && *review.IsSpoiler,
-		utils.MysqlUuid(review.UserID),
-		utils.MysqlUuid(review.MovieID),
+		review.UserID,
+		review.MovieID,
 	)
 
 	result, err := stmt.Exec(rr.DatabaseManager.GetDatabaseConnection())
@@ -56,7 +56,7 @@ func (rr *ReviewRepository) CreateReview(review model.Reviews) *models.KTSError 
 	return nil
 }
 
-func (rr *ReviewRepository) GetReviewById(id *uuid.UUID) (*model.Reviews, *models.KTSError) {
+func (rr *ReviewRepository) GetReviewById(id *myid.UUID) (*model.Reviews, *models.KTSError) {
 	var review model.Reviews
 	stmt := table.Reviews.SELECT(
 		table.Reviews.ID,
@@ -67,7 +67,7 @@ func (rr *ReviewRepository) GetReviewById(id *uuid.UUID) (*model.Reviews, *model
 		table.Reviews.UserID,
 		table.Reviews.MovieID,
 	).WHERE(
-		table.Reviews.ID.EQ(utils.MysqlUuid(id)),
+		table.Reviews.ID.EQ(utils.MysqlUuid(*id)),
 	)
 
 	err := stmt.Query(rr.DatabaseManager.GetDatabaseConnection(), &review)
@@ -81,8 +81,8 @@ func (rr *ReviewRepository) GetReviewById(id *uuid.UUID) (*model.Reviews, *model
 	return &review, nil
 }
 
-func (rr *ReviewRepository) DeleteReview(id *uuid.UUID) *models.KTSError {
-	stmt := table.Reviews.DELETE().WHERE(table.Reviews.ID.EQ(utils.MysqlUuid(id)))
+func (rr *ReviewRepository) DeleteReview(id *myid.UUID) *models.KTSError {
+	stmt := table.Reviews.DELETE().WHERE(table.Reviews.ID.EQ(utils.MysqlUuid(*id)))
 	result, err := stmt.Exec(rr.DatabaseManager.GetDatabaseConnection())
 	if err != nil {
 		return kts_errors.KTS_INTERNAL_ERROR
@@ -98,8 +98,8 @@ func (rr *ReviewRepository) DeleteReview(id *uuid.UUID) *models.KTSError {
 	return nil
 }
 
-func (rr *ReviewRepository) DeleteReviewForMovie(movieId *uuid.UUID) *models.KTSError {
-	stmt := table.Reviews.DELETE().WHERE(table.Reviews.MovieID.EQ(utils.MysqlUuid(movieId)))
+func (rr *ReviewRepository) DeleteReviewForMovie(movieId *myid.UUID) *models.KTSError {
+	stmt := table.Reviews.DELETE().WHERE(table.Reviews.MovieID.EQ(utils.MysqlUuid(*movieId)))
 	log.Print(stmt.DebugSql())
 	_, err := stmt.Exec(rr.DatabaseManager.GetDatabaseConnection())
 	if err != nil {

--- a/src/repositories/review_repository_test.go
+++ b/src/repositories/review_repository_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/managers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/samples"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -30,13 +30,13 @@ func TestCreateReview(t *testing.T) {
 					"INSERT INTO `KinoTicketSystem`.reviews (id, rating, comment, datetime, is_spoiler, user_id, movie_id)\n"+
 						"VALUES (?, ?, ?, ?, ?, ?, ?);",
 				).WithArgs(
-					utils.EqUUID(review.ID),
+					review.ID,
 					review.Rating,
 					review.Comment,
 					review.Datetime,
 					review.IsSpoiler,
-					utils.EqUUID(review.UserID),
-					utils.EqUUID(review.MovieID),
+					review.UserID,
+					review.MovieID,
 				).WillReturnResult(
 					sqlmock.NewResult(1, 1),
 				)
@@ -51,13 +51,13 @@ func TestCreateReview(t *testing.T) {
 					"INSERT INTO `KinoTicketSystem`.reviews (id, rating, comment, datetime, is_spoiler, user_id, movie_id)\n"+
 						"VALUES (?, ?, ?, ?, ?, ?, ?);",
 				).WithArgs(
-					utils.EqUUID(review.ID),
+					review.ID,
 					review.Rating,
 					review.Comment,
 					review.Datetime,
 					review.IsSpoiler,
-					utils.EqUUID(review.UserID),
-					utils.EqUUID(review.MovieID),
+					review.UserID,
+					review.MovieID,
 				).WillReturnError(
 					sqlmock.ErrCancelled,
 				)
@@ -72,13 +72,13 @@ func TestCreateReview(t *testing.T) {
 					"INSERT INTO `KinoTicketSystem`.reviews (id, rating, comment, datetime, is_spoiler, user_id, movie_id)\n"+
 						"VALUES (?, ?, ?, ?, ?, ?, ?);",
 				).WithArgs(
-					utils.EqUUID(review.ID),
+					review.ID,
 					review.Rating,
 					review.Comment,
 					review.Datetime,
 					review.IsSpoiler,
-					utils.EqUUID(review.UserID),
-					utils.EqUUID(review.MovieID),
+					review.UserID,
+					review.MovieID,
 				).WillReturnResult(
 					sqlmock.NewErrorResult(sqlmock.ErrCancelled),
 				)
@@ -93,13 +93,13 @@ func TestCreateReview(t *testing.T) {
 					"INSERT INTO `KinoTicketSystem`.reviews (id, rating, comment, datetime, is_spoiler, user_id, movie_id)\n"+
 						"VALUES (?, ?, ?, ?, ?, ?, ?);",
 				).WithArgs(
-					utils.EqUUID(review.ID),
+					review.ID,
 					review.Rating,
 					review.Comment,
 					review.Datetime,
 					review.IsSpoiler,
-					utils.EqUUID(review.UserID),
-					utils.EqUUID(review.MovieID),
+					review.UserID,
+					review.MovieID,
 				).WillReturnResult(
 					sqlmock.NewResult(0, 0),
 				)
@@ -152,19 +152,19 @@ func TestGetReview(t *testing.T) {
 		"WHERE reviews.id = ?;"
 	testCases := []struct {
 		name            string
-		id              uuid.UUID
-		setExpectations func(mock sqlmock.Sqlmock, id uuid.UUID)
+		id              myid.UUID
+		setExpectations func(mock sqlmock.Sqlmock, id myid.UUID)
 		expectedReview  *model.Reviews
 		expectedError   *models.KTSError
 	}{
 		{
 			name: "Success",
-			id:   uuid.New(),
-			setExpectations: func(mock sqlmock.Sqlmock, id uuid.UUID) {
+			id:   myid.New(),
+			setExpectations: func(mock sqlmock.Sqlmock, id myid.UUID) {
 				mock.ExpectQuery(
 					query,
 				).WithArgs(
-					utils.EqUUID(&id),
+					utils.EqUUID(id),
 				).WillReturnRows(
 					sqlmock.NewRows([]string{"reviews.id", "reviews.rating", "reviews.comment", "reviews.datetime", "reviews.is_spoiler", "reviews.user_id", "reviews.movie_id"}).
 						AddRow(
@@ -183,12 +183,12 @@ func TestGetReview(t *testing.T) {
 		},
 		{
 			name: "Internal error",
-			id:   uuid.New(),
-			setExpectations: func(mock sqlmock.Sqlmock, id uuid.UUID) {
+			id:   myid.New(),
+			setExpectations: func(mock sqlmock.Sqlmock, id myid.UUID) {
 				mock.ExpectQuery(
 					query,
 				).WithArgs(
-					utils.EqUUID(&id),
+					utils.EqUUID(id),
 				).WillReturnError(
 					sqlmock.ErrCancelled,
 				)
@@ -198,12 +198,12 @@ func TestGetReview(t *testing.T) {
 		},
 		{
 			name: "Not found",
-			id:   uuid.New(),
-			setExpectations: func(mock sqlmock.Sqlmock, id uuid.UUID) {
+			id:   myid.New(),
+			setExpectations: func(mock sqlmock.Sqlmock, id myid.UUID) {
 				mock.ExpectQuery(
 					query,
 				).WithArgs(
-					utils.EqUUID(&id),
+					utils.EqUUID(id),
 				).WillReturnError(
 					sql.ErrNoRows,
 				)
@@ -249,19 +249,19 @@ func TestGetReview(t *testing.T) {
 func TestDeleteReview(t *testing.T) {
 	testCases := []struct {
 		name            string
-		id              uuid.UUID
-		setExpectations func(mock sqlmock.Sqlmock, id uuid.UUID)
+		id              myid.UUID
+		setExpectations func(mock sqlmock.Sqlmock, id myid.UUID)
 		expectedError   *models.KTSError
 	}{
 		{
 			name: "Success",
-			id:   uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
-			setExpectations: func(mock sqlmock.Sqlmock, id uuid.UUID) {
+			id:   myid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
+			setExpectations: func(mock sqlmock.Sqlmock, id myid.UUID) {
 				mock.ExpectExec(
 					"DELETE FROM `KinoTicketSystem`.reviews\n" +
 						"WHERE reviews.id = ?;",
 				).WithArgs(
-					utils.EqUUID(&id),
+					utils.EqUUID(id),
 				).WillReturnResult(
 					sqlmock.NewResult(1, 1),
 				)
@@ -270,13 +270,13 @@ func TestDeleteReview(t *testing.T) {
 		},
 		{
 			name: "Delete internal error",
-			id:   uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
-			setExpectations: func(mock sqlmock.Sqlmock, id uuid.UUID) {
+			id:   myid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
+			setExpectations: func(mock sqlmock.Sqlmock, id myid.UUID) {
 				mock.ExpectExec(
 					"DELETE FROM `KinoTicketSystem`.reviews\n" +
 						"WHERE reviews.id = ?;",
 				).WithArgs(
-					utils.EqUUID(&id),
+					utils.EqUUID(id),
 				).WillReturnError(
 					sqlmock.ErrCancelled,
 				)
@@ -285,13 +285,13 @@ func TestDeleteReview(t *testing.T) {
 		},
 		{
 			name: "Rows affected internal error",
-			id:   uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
-			setExpectations: func(mock sqlmock.Sqlmock, id uuid.UUID) {
+			id:   myid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
+			setExpectations: func(mock sqlmock.Sqlmock, id myid.UUID) {
 				mock.ExpectExec(
 					"DELETE FROM `KinoTicketSystem`.reviews\n" +
 						"WHERE reviews.id = ?;",
 				).WithArgs(
-					utils.EqUUID(&id),
+					utils.EqUUID(id),
 				).WillReturnResult(
 					sqlmock.NewErrorResult(sqlmock.ErrCancelled),
 				)
@@ -300,13 +300,13 @@ func TestDeleteReview(t *testing.T) {
 		},
 		{
 			name: "No rows affected",
-			id:   uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
-			setExpectations: func(mock sqlmock.Sqlmock, id uuid.UUID) {
+			id:   myid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
+			setExpectations: func(mock sqlmock.Sqlmock, id myid.UUID) {
 				mock.ExpectExec(
 					"DELETE FROM `KinoTicketSystem`.reviews\n" +
 						"WHERE reviews.id = ?;",
 				).WithArgs(
-					utils.EqUUID(&id),
+					utils.EqUUID(id),
 				).WillReturnResult(
 					sqlmock.NewResult(0, 0),
 				)
@@ -349,19 +349,19 @@ func TestDeleteReview(t *testing.T) {
 func TestDeleteReviewForMovie(t *testing.T) {
 	testCases := []struct {
 		name            string
-		movieId         uuid.UUID
-		setExpectations func(mock sqlmock.Sqlmock, movieId uuid.UUID)
+		movieId         myid.UUID
+		setExpectations func(mock sqlmock.Sqlmock, movieId myid.UUID)
 		expectedError   *models.KTSError
 	}{
 		{
 			name:    "Success",
-			movieId: uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
-			setExpectations: func(mock sqlmock.Sqlmock, movieId uuid.UUID) {
+			movieId: myid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
+			setExpectations: func(mock sqlmock.Sqlmock, movieId myid.UUID) {
 				mock.ExpectExec(
 					"DELETE FROM `KinoTicketSystem`.reviews\n" +
 						"WHERE reviews.movie_id = ?;",
 				).WithArgs(
-					utils.EqUUID(&movieId),
+					utils.EqUUID(movieId),
 				).WillReturnResult(
 					sqlmock.NewResult(1, 1),
 				)
@@ -370,13 +370,13 @@ func TestDeleteReviewForMovie(t *testing.T) {
 		},
 		{
 			name:    "Delete internal error",
-			movieId: uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
-			setExpectations: func(mock sqlmock.Sqlmock, movieId uuid.UUID) {
+			movieId: myid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
+			setExpectations: func(mock sqlmock.Sqlmock, movieId myid.UUID) {
 				mock.ExpectExec(
 					"DELETE FROM `KinoTicketSystem`.reviews\n" +
 						"WHERE reviews.movie_id = ?;",
 				).WithArgs(
-					utils.EqUUID(&movieId),
+					utils.EqUUID(movieId),
 				).WillReturnError(
 					sqlmock.ErrCancelled,
 				)

--- a/src/repositories/theatre_repository_test.go
+++ b/src/repositories/theatre_repository_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/managers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/samples"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
 	"github.com/stretchr/testify/assert"
@@ -27,10 +28,10 @@ func TestCreateTheatre(t *testing.T) {
 			data: samples.GetSampleTheatre(),
 			setExpectations: func(mock sqlmock.Sqlmock, theatre *model.Theatres) {
 				mock.ExpectExec("INSERT INTO `KinoTicketSystem`.theatres").WithArgs(
-					utils.EqUUID(theatre.ID),
+					theatre.ID,
 					theatre.Name,
 					*theatre.LogoURL,
-					utils.EqUUID(theatre.AddressID),
+					theatre.AddressID,
 				).WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 			expectedError: nil,
@@ -40,10 +41,10 @@ func TestCreateTheatre(t *testing.T) {
 			data: samples.GetSampleTheatre(),
 			setExpectations: func(mock sqlmock.Sqlmock, theatre *model.Theatres) {
 				mock.ExpectExec("INSERT INTO `KinoTicketSystem`.theatres").WithArgs(
-					utils.EqUUID(theatre.ID),
+					theatre.ID,
 					theatre.Name,
 					*theatre.LogoURL,
-					utils.EqUUID(theatre.AddressID),
+					theatre.AddressID,
 				).WillReturnError(sql.ErrConnDone)
 			},
 			expectedError: kts_errors.KTS_INTERNAL_ERROR,
@@ -95,10 +96,10 @@ func TestCreateCinemaHall(t *testing.T) {
 				mock.ExpectExec(
 					"INSERT INTO `KinoTicketSystem`.cinema_halls",
 				).WithArgs(
-					utils.EqUUID(cinemaHall.ID),
+					cinemaHall.ID,
 					cinemaHall.Name,
 					cinemaHall.Capacity,
-					utils.EqUUID(cinemaHall.TheatreID),
+					cinemaHall.TheatreID,
 				).WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 			expectedError: nil,
@@ -110,10 +111,10 @@ func TestCreateCinemaHall(t *testing.T) {
 				mock.ExpectExec(
 					"INSERT INTO `KinoTicketSystem`.cinema_halls",
 				).WithArgs(
-					utils.EqUUID(cinemaHall.ID),
+					cinemaHall.ID,
 					cinemaHall.Name,
 					cinemaHall.Capacity,
-					utils.EqUUID(cinemaHall.TheatreID),
+					cinemaHall.TheatreID,
 				).WillReturnError(sql.ErrConnDone)
 			},
 			expectedError: kts_errors.KTS_INTERNAL_ERROR,
@@ -201,7 +202,7 @@ func TestGetCinemaHallsForTheatre(t *testing.T) {
 				)
 			},
 			expectedCinemaHalls: nil,
-			expectedError: 	 kts_errors.KTS_NOT_FOUND,
+			expectedError:       kts_errors.KTS_NOT_FOUND,
 		},
 	}
 
@@ -221,7 +222,7 @@ func TestGetCinemaHallsForTheatre(t *testing.T) {
 
 			tc.setExpectations(mock)
 
-			cinemaHalls, ktsErr := theatreRepo.GetCinemaHallsForTheatre(theatreId)
+			cinemaHalls, ktsErr := theatreRepo.GetCinemaHallsForTheatre(&theatreId)
 
 			if err := mock.ExpectationsWereMet(); err != nil {
 				t.Errorf("There were unfulfilled expectations: %s", err)
@@ -247,13 +248,13 @@ func TestCreateSeat(t *testing.T) {
 				mock.ExpectExec(
 					"INSERT INTO `KinoTicketSystem`.seats",
 				).WithArgs(
-					utils.EqUUID(seat.ID),
+					seat.ID,
 					seat.RowNr,
 					seat.ColumnNr,
 					seat.VisibleRowNr,
 					seat.VisibleColumnNr,
-					utils.EqUUID(seat.SeatCategoryID),
-					utils.EqUUID(seat.CinemaHallID),
+					seat.SeatCategoryID,
+					seat.CinemaHallID,
 					seat.Type,
 				).WillReturnResult(sqlmock.NewResult(1, 1))
 			},
@@ -271,8 +272,8 @@ func TestCreateSeat(t *testing.T) {
 					seat.ColumnNr,
 					seat.VisibleRowNr,
 					seat.VisibleColumnNr,
-					utils.EqUUID(seat.SeatCategoryID),
-					utils.EqUUID(seat.CinemaHallID),
+					seat.SeatCategoryID,
+					seat.CinemaHallID,
 					seat.Type,
 				).WillReturnError(sql.ErrConnDone)
 			},
@@ -381,22 +382,22 @@ func TestGetSeatCategories(t *testing.T) {
 }
 
 func TestGetSeatsForCinemaHall(t *testing.T) {
-	cinemaHallID := utils.NewUUID()
+	cinemaHallID := myid.NewUUID()
 
 	expectedSeats := []model.Seats{
 		{
-			ID:             utils.NewUUID(),
-			CinemaHallID:   cinemaHallID,
+			ID:             myid.New(),
+			CinemaHallID:   *cinemaHallID,
 			ColumnNr:       1,
 			RowNr:          1,
-			SeatCategoryID: utils.NewUUID(),
+			SeatCategoryID: myid.New(),
 		},
 		{
-			ID:             utils.NewUUID(),
-			CinemaHallID:   cinemaHallID,
+			ID:             myid.New(),
+			CinemaHallID:   *cinemaHallID,
 			ColumnNr:       2,
 			RowNr:          1,
-			SeatCategoryID: utils.NewUUID(),
+			SeatCategoryID: myid.New(),
 		},
 	}
 

--- a/src/repositories/ticket_repository_test.go
+++ b/src/repositories/ticket_repository_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/managers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/samples"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,14 +33,14 @@ func TestGetTicketById(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		setExpectations func(mock sqlmock.Sqlmock, id *uuid.UUID)
+		setExpectations func(mock sqlmock.Sqlmock, id *myid.UUID)
 		expectedTicket  *models.TicketDTO
 		expectedError   *models.KTSError
 	}{
 		{
 			name: "Ticket found",
-			setExpectations: func(mock sqlmock.Sqlmock, id *uuid.UUID) {
-				mock.ExpectQuery(query).WithArgs(utils.EqUUID(ticketId)).WillReturnRows(
+			setExpectations: func(mock sqlmock.Sqlmock, id *myid.UUID) {
+				mock.ExpectQuery(query).WithArgs(utils.EqUUID(*ticketId)).WillReturnRows(
 					sqlmock.NewRows(
 						[]string{"ticket.id", "ticket.validated", "ticket.price", "seats.id", "seats.row_nr", "seats.column_nr", "seats.visible_row_nr", "seats.visible_column_nr", "seats.seat_category_id", "seats.cinema_hall_id", "seats.type", "events.id", "events.title", "events.start", "events.end", "events.description", "events.event_type", "events.cinema_hall_id", "orders.id", "orders.totalprice", "orders.is_paid", "orders.payment_method_id", "orders.user_id"},
 					).AddRow(
@@ -53,8 +53,8 @@ func TestGetTicketById(t *testing.T) {
 		},
 		{
 			name: "Ticket conflict",
-			setExpectations: func(mock sqlmock.Sqlmock, id *uuid.UUID) {
-				mock.ExpectQuery(query).WithArgs(utils.EqUUID(ticketId)).WillReturnRows(
+			setExpectations: func(mock sqlmock.Sqlmock, id *myid.UUID) {
+				mock.ExpectQuery(query).WithArgs(utils.EqUUID(*ticketId)).WillReturnRows(
 					sqlmock.NewRows([]string{"ticket.id", "ticket.validated", "ticket.price", "seats.id", "seats.row_nr", "seats.column_nr", "seats.visible_row_nr", "seats.visible_column_nr", "seats.seat_category_id", "seats.cinema_hall_id", "seats.type", "events.id", "events.title", "events.start", "events.end", "events.description", "events.event_type", "events.cinema_hall_id", "orders.id", "orders.totalprice", "orders.is_paid", "orders.payment_method_id", "orders.user_id"}),
 				)
 			},
@@ -63,8 +63,8 @@ func TestGetTicketById(t *testing.T) {
 		},
 		{
 			name: "Error while querying Ticket",
-			setExpectations: func(mock sqlmock.Sqlmock, id *uuid.UUID) {
-				mock.ExpectQuery(query).WithArgs(utils.EqUUID(ticketId)).WillReturnError(sqlmock.ErrCancelled)
+			setExpectations: func(mock sqlmock.Sqlmock, id *myid.UUID) {
+				mock.ExpectQuery(query).WithArgs(utils.EqUUID(*ticketId)).WillReturnError(sqlmock.ErrCancelled)
 			},
 			expectedTicket: nil,
 			expectedError:  kts_errors.KTS_INTERNAL_ERROR,
@@ -192,32 +192,32 @@ func TestCreateTicket(t *testing.T) {
 }
 
 func TestValidateTicket(t *testing.T) {
-	ticketID := utils.NewUUID()
+	ticketID := myid.NewUUID()
 
 	query := "UPDATE `KinoTicketSystem`.tickets SET validated = ? WHERE tickets.id = ?;"
 
 	testCases := []struct {
 		name            string
-		setExpectations func(mock sqlmock.Sqlmock, id *uuid.UUID)
+		setExpectations func(mock sqlmock.Sqlmock, id *myid.UUID)
 		expectedError   *models.KTSError
 	}{
 		{
 			name: "Validated Ticket successfully",
-			setExpectations: func(mock sqlmock.Sqlmock, id *uuid.UUID) {
-				mock.ExpectExec(query).WithArgs(true, utils.EqUUID(ticketID)).WillReturnResult(sqlmock.NewResult(1, 1))
+			setExpectations: func(mock sqlmock.Sqlmock, id *myid.UUID) {
+				mock.ExpectExec(query).WithArgs(true, utils.EqUUID(*ticketID)).WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 			expectedError: nil,
 		},
 		{
 			name: "Error while validating ticket",
-			setExpectations: func(mock sqlmock.Sqlmock, id *uuid.UUID) {
+			setExpectations: func(mock sqlmock.Sqlmock, id *myid.UUID) {
 				mock.ExpectExec(query).WithArgs(true, sqlmock.AnyArg()).WillReturnError(sqlmock.ErrCancelled)
 			},
 			expectedError: kts_errors.KTS_INTERNAL_ERROR,
 		},
 		{
 			name: "Error while converting rows affected",
-			setExpectations: func(mock sqlmock.Sqlmock, id *uuid.UUID) {
+			setExpectations: func(mock sqlmock.Sqlmock, id *myid.UUID) {
 				mock.ExpectExec(query).WithArgs(true, sqlmock.AnyArg()).WillReturnResult(
 					sqlmock.NewErrorResult(errors.New("rows affected conversion did not work")),
 				)
@@ -226,7 +226,7 @@ func TestValidateTicket(t *testing.T) {
 		},
 		{
 			name: "Ticket conflict",
-			setExpectations: func(mock sqlmock.Sqlmock, id *uuid.UUID) {
+			setExpectations: func(mock sqlmock.Sqlmock, id *myid.UUID) {
 				mock.ExpectExec(query).WithArgs(true, sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 0))
 			},
 			expectedError: kts_errors.KTS_CONFLICT,

--- a/src/repositories/user_movies_repository.go
+++ b/src/repositories/user_movies_repository.go
@@ -5,21 +5,21 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/table"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/managers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
 )
 
 type UserMovieRepositoryI interface {
-	RemoveAllUserMovieCombinationWithMovie(movieId *uuid.UUID) *models.KTSError
+	RemoveAllUserMovieCombinationWithMovie(movieId *myid.UUID) *models.KTSError
 }
 
 type UserMovieRepository struct {
 	DatabaseManager managers.DatabaseManagerI
 }
 
-func (umr *UserMovieRepository) RemoveAllUserMovieCombinationWithMovie(movieId *uuid.UUID) *models.KTSError {
+func (umr *UserMovieRepository) RemoveAllUserMovieCombinationWithMovie(movieId *myid.UUID) *models.KTSError {
 	deleteQuery := table.UserMovies.DELETE().WHERE(
-		table.UserMovies.MovieID.EQ(utils.MysqlUuid(movieId)),
+		table.UserMovies.MovieID.EQ(utils.MysqlUuid(*movieId)),
 	)
 
 	// Execute the query

--- a/src/repositories/user_movies_repository_test.go
+++ b/src/repositories/user_movies_repository_test.go
@@ -7,32 +7,32 @@ import (
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/managers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRemoveAllUserMovieCombinationWithMovie(t *testing.T) {
 
-	movieId := uuid.New()
+	movieId := myid.New()
 
 	query := "DELETE FROM `KinoTicketSystem`.user_movies WHERE user_movies.movie_id = ?;"
 
 	testCases := []struct {
 		name            string
-		setExpectations func(mock sqlmock.Sqlmock, movieId *uuid.UUID)
+		setExpectations func(mock sqlmock.Sqlmock)
 		expectedError   *models.KTSError
 	}{
 		{
 			name: "Remove all movies corresponding to one movieId",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID) {
+			setExpectations: func(mock sqlmock.Sqlmock) {
 				mock.ExpectExec(query).WithArgs(utils.EqUUID(movieId)).WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 			expectedError: nil,
 		},
 		{
 			name: "Error while removing user_movies",
-			setExpectations: func(mock sqlmock.Sqlmock, movieId *uuid.UUID) {
+			setExpectations: func(mock sqlmock.Sqlmock) {
 				mock.ExpectExec(query).WithArgs(utils.EqUUID(movieId)).WillReturnError(sqlmock.ErrCancelled)
 			},
 			expectedError: kts_errors.KTS_INTERNAL_ERROR,
@@ -55,7 +55,7 @@ func TestRemoveAllUserMovieCombinationWithMovie(t *testing.T) {
 				},
 			}
 
-			tc.setExpectations(mock, &movieId)
+			tc.setExpectations(mock)
 
 			// Call the method under test
 			kts_err := userMovieRepo.RemoveAllUserMovieCombinationWithMovie(&movieId)

--- a/src/repositories/user_repo.go
+++ b/src/repositories/user_repo.go
@@ -9,13 +9,13 @@ import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/table"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/managers"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
 	"github.com/go-jet/jet/v2/mysql"
-	"github.com/google/uuid"
 )
 
 type UserRepositoryI interface {
-	GetUserById(id *uuid.UUID) (*model.Users, *models.KTSError)
+	GetUserById(id *myid.UUID) (*model.Users, *models.KTSError)
 	GetUserByUsername(username string) (*model.Users, *models.KTSError)
 	CreateUser(user model.Users) *models.KTSError
 	CheckIfUsernameExists(username string) *models.KTSError
@@ -26,7 +26,7 @@ type UserRepository struct {
 	DatabaseManager managers.DatabaseManagerI
 }
 
-func (ur *UserRepository) GetUserById(id *uuid.UUID) (*model.Users, *models.KTSError) {
+func (ur *UserRepository) GetUserById(id *myid.UUID) (*model.Users, *models.KTSError) {
 	var user model.Users
 	stmt := mysql.SELECT(
 		table.Users.ID,
@@ -38,7 +38,7 @@ func (ur *UserRepository) GetUserById(id *uuid.UUID) (*model.Users, *models.KTSE
 	).FROM(
 		table.Users,
 	).WHERE(
-		table.Users.ID.EQ(utils.MysqlUuid(id)),
+		table.Users.ID.EQ(utils.MysqlUuid(*id)),
 	)
 	err := stmt.Query(ur.DatabaseManager.GetDatabaseConnection(), &user)
 	if err != nil {

--- a/src/repositories/user_repo_test.go
+++ b/src/repositories/user_repo_test.go
@@ -107,7 +107,7 @@ func TestGetUserById(t *testing.T) {
 
 			// WHEN
 			// call GetUserByUsername with username
-			user, kts_err := userRepo.GetUserById(id)
+			user, kts_err := userRepo.GetUserById(&id)
 
 			// THEN
 			// check expected error, user and expectations

--- a/src/samples/actor_samples.go
+++ b/src/samples/actor_samples.go
@@ -5,28 +5,28 @@ import (
 
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 func GetSampleActor() *models.ActorDTO {
 
-	actorId := uuid.New()
+	actorId := myid.New()
 
 	url1 := "https://de.wikipedia.org/wiki/Brad_Pitt#/media/Datei:SevenYearsInTibeta.jpg"
 	url2 := "https://en.wikipedia.org/wiki/Brad_Pitt_filmography#/media/File:Brad_Pitt_Fury_2014.jpg"
 
-	picId1 := uuid.New()
-	picId2 := uuid.New()
+	picId1 := myid.New()
+	picId2 := myid.New()
 
 	picture1 := model.ActorPictures{
-		ID:      &picId1,
-		ActorID: &actorId,
+		ID:      picId1,
+		ActorID: actorId,
 		PicURL:  &url1,
 	}
 
 	picture2 := model.ActorPictures{
-		ID:      &picId2,
-		ActorID: &actorId,
+		ID:      picId2,
+		ActorID: actorId,
 		PicURL:  &url2,
 	}
 
@@ -35,11 +35,11 @@ func GetSampleActor() *models.ActorDTO {
 
 	rating := 0.
 
-	movieId1 := uuid.New()
-	movieId2 := uuid.New()
+	movieId1 := myid.New()
+	movieId2 := myid.New()
 
 	movie1 := model.Movies{
-		ID:           &movieId1,
+		ID:           movieId1,
 		Title:        "The Godfather",
 		Description:  "The aging patriarch of an organized crime dynasty transfers control of his clandestine empire to his reluctant son.",
 		BannerPicURL: nil,
@@ -52,7 +52,7 @@ func GetSampleActor() *models.ActorDTO {
 	}
 
 	movie2 := model.Movies{
-		ID:           &movieId2,
+		ID:           movieId2,
 		Title:        "Fight Club",
 		Description:  "An insomniac office worker and a devil-may-care soapmaker form an underground fight club that evolves into something much, much more.",
 		BannerPicURL: nil,
@@ -66,7 +66,7 @@ func GetSampleActor() *models.ActorDTO {
 
 	actor := models.ActorDTO{
 		Actors: model.Actors{
-			ID:          &actorId,
+			ID:          actorId,
 			Name:        "Brad Pitt",
 			Description: "Brad Pitt is an actor.",
 			Birthdate:   time.Date(1963, 12, 18, 0, 0, 0, 0, time.UTC),
@@ -84,24 +84,23 @@ func GetSampleActor() *models.ActorDTO {
 	return &actor
 }
 
-
 func GetSampleActors() *[]models.GetActorsDTO {
 
-	actor1Id := uuid.New()
+	actor1Id := myid.New()
 
 	url := "BradPitt.jpg"
 
-	pic1Id := uuid.New()
+	pic1Id := myid.New()
 
 	actor1Picture := model.ActorPictures{
-		ID:      &pic1Id,
-		ActorID: &actor1Id,
+		ID:      pic1Id,
+		ActorID: actor1Id,
 		PicURL:  &url,
 	}
 
 	actor1 := models.GetActorsDTO{
 		Actors: model.Actors{
-			ID:          &actor1Id,
+			ID:          actor1Id,
 			Name:        "Brad Pitt",
 			Description: "Brad Pitt is an actor.",
 			Birthdate:   time.Date(1963, 12, 18, 0, 0, 0, 0, time.UTC),
@@ -111,21 +110,21 @@ func GetSampleActors() *[]models.GetActorsDTO {
 		},
 	}
 
-	actor2Id := uuid.New()
+	actor2Id := myid.New()
 
 	url2 := "EdwardNorton.jpg"
 
-	pic2Id := uuid.New()
+	pic2Id := myid.New()
 
 	actor2Picture := model.ActorPictures{
-		ID:      &pic2Id,
-		ActorID: &actor2Id,
+		ID:      pic2Id,
+		ActorID: actor2Id,
 		PicURL:  &url2,
 	}
 
 	actor2 := models.GetActorsDTO{
 		Actors: model.Actors{
-			ID:          &actor2Id,
+			ID:          actor2Id,
 			Name:        "Edward Norton",
 			Description: "Edward Norton is an actor.",
 			Birthdate:   time.Date(1969, 8, 18, 0, 0, 0, 0, time.UTC),

--- a/src/samples/event_samples.go
+++ b/src/samples/event_samples.go
@@ -5,25 +5,25 @@ import (
 
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
 )
 
-func GetGetSpecialEventsDTO(eventId *uuid.UUID) *models.GetSpecialEventsDTO {
+func GetGetSpecialEventsDTO(eventId *myid.UUID) *models.GetSpecialEventsDTO {
 	rating := 4.5
 	return &models.GetSpecialEventsDTO{
 		Events: model.Events{
-			ID:           eventId,
+			ID:           *eventId,
 			Title:        "My Events",
 			Start:        time.Now(),
 			End:          time.Now().Add(time.Hour),
 			Description:  utils.GetStringPointer("MyDescription"),
 			EventType:    "special event",
-			CinemaHallID: utils.NewUUID(),
+			CinemaHallID: myid.New(),
 		},
 		Movies: []*model.Movies{
 			{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				Title:        "The Godfather",
 				Description:  "The Godfather \"Don\" Vito Corleone is the head of the Corleone mafia family in New York. He is at the event of his daughter's wedding. Michael, Vito's youngest son and a decorated WW II Marine is also present at the wedding. Michael seems to be uninterested in being a part of the family business. Vito is a powerful man, and is kind to all those who give him respect but is ruthless against those who do not. But when a powerful and treacherous rival wants to sell drugs and needs the Don's influence for the same, Vito refuses to do it. What follows is a clash between Vito's fading old values and the new ways which may cause Michael to do the thing he was most reluctant in doing and wage a mob war against all the other mafia families which could tear the Corleone family apart.",
 				BannerPicURL: utils.GetStringPointer("https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcREKr_g8JfVvWEiTS_17e4p8o-0RQHc9ydl6xlhSM9-vCBUXumK-b3bNPv0LRM_aTGacQ&usqp=CAU"),
@@ -35,7 +35,7 @@ func GetGetSpecialEventsDTO(eventId *uuid.UUID) *models.GetSpecialEventsDTO {
 				Fsk:          16,
 			},
 			{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				Title:        "The Dark Knight",
 				Description:  "When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, Batman must accept one of the greatest psychological and physical tests of his ability to fight injustice.",
 				BannerPicURL: utils.GetStringPointer("https://images.moviesanywhere.com/9d3294ee14822bbb81e24bb0a9610b98/d030d491-7a4a-42aa-832f-b2fd25d5b1f8.jpg?r=3x1&w=2400"),
@@ -52,22 +52,22 @@ func GetGetSpecialEventsDTO(eventId *uuid.UUID) *models.GetSpecialEventsDTO {
 
 func GetModelEvents() []*model.Events {
 	return []*model.Events{{
-		ID:           utils.NewUUID(),
+		ID:           myid.New(),
 		Title:        "Test Event 1",
 		Start:        time.Now(),
 		End:          time.Now().Add(time.Hour),
 		Description:  nil,
 		EventType:    "Test event type 1",
-		CinemaHallID: utils.NewUUID(),
+		CinemaHallID: myid.New(),
 	},
 		{
-			ID:           utils.NewUUID(),
+			ID:           myid.New(),
 			Title:        "Test Event 2",
 			Start:        time.Now(),
 			End:          time.Now().Add(time.Hour),
 			Description:  nil,
 			EventType:    "Test event type 2",
-			CinemaHallID: utils.NewUUID(),
+			CinemaHallID: myid.New(),
 		},
 	}
 }

--- a/src/samples/eventseat_samples.go
+++ b/src/samples/eventseat_samples.go
@@ -2,62 +2,62 @@ package samples
 
 import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 )
 
 func GetEventSeatsDTO() *[]models.GetEventSeatsDTO {
-	eventId := utils.NewUUID()
+	eventId := myid.NewUUID()
 
 	return &[]models.GetEventSeatsDTO{
 		{
 			EventSeat: model.EventSeats{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				Booked:       false,
 				BlockedUntil: nil,
 				UserID:       nil,
-				EventID:      eventId,
-				SeatID:       utils.NewUUID(),
+				EventID:      *eventId,
+				SeatID:       myid.New(),
 			},
 			Seat: model.Seats{
-				ID:             utils.NewUUID(),
+				ID:             myid.New(),
 				RowNr:          1,
 				ColumnNr:       1,
-				SeatCategoryID: utils.NewUUID(),
+				SeatCategoryID: myid.New(),
 			},
 			SeatCategory: model.SeatCategories{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				CategoryName: "standard",
 			},
 			EventSeatCategory: model.EventSeatCategories{
-				EventID:        eventId,
-				SeatCategoryID: utils.NewUUID(),
+				EventID:        *eventId,
+				SeatCategoryID: myid.New(),
 				Price:          100,
 			},
 		},
 		{
 			EventSeat: model.EventSeats{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				Booked:       false,
 				BlockedUntil: nil,
 				UserID:       nil,
-				EventID:      eventId,
-				SeatID:       utils.NewUUID(),
+				EventID:      *eventId,
+				SeatID:       myid.New(),
 			},
 			Seat: model.Seats{
-				ID:             utils.NewUUID(),
+				ID:             myid.New(),
 				RowNr:          1,
 				ColumnNr:       2,
-				SeatCategoryID: utils.NewUUID(),
+				SeatCategoryID: myid.New(),
 			},
 			SeatCategory: model.SeatCategories{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				CategoryName: "standard",
 			},
 			EventSeatCategory: model.EventSeatCategories{
-				EventID:        eventId,
-				SeatCategoryID: utils.NewUUID(),
+				EventID:        *eventId,
+				SeatCategoryID: myid.New(),
 				Price:          100,
 			},
 		},
@@ -65,56 +65,56 @@ func GetEventSeatsDTO() *[]models.GetEventSeatsDTO {
 }
 
 func GetGetSlectedSeatsDTO() *[]models.GetSlectedSeatsDTO {
-	eventId := utils.NewUUID()
+	eventId := myid.NewUUID()
 
 	return &[]models.GetSlectedSeatsDTO{
 		{
 			EventSeat: model.EventSeats{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				Booked:       false,
 				BlockedUntil: nil,
 				UserID:       nil,
-				EventID:      eventId,
-				SeatID:       utils.NewUUID(),
+				EventID:      *eventId,
+				SeatID:       myid.New(),
 			},
 			Seat: model.Seats{
-				ID:             utils.NewUUID(),
+				ID:             myid.New(),
 				RowNr:          1,
 				ColumnNr:       1,
-				SeatCategoryID: utils.NewUUID(),
+				SeatCategoryID: myid.New(),
 			},
 			SeatCategory: model.SeatCategories{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				CategoryName: "standard",
 			},
 			EventSeatCategory: model.EventSeatCategories{
-				EventID:        eventId,
-				SeatCategoryID: utils.NewUUID(),
+				EventID:        *eventId,
+				SeatCategoryID: myid.New(),
 				Price:          100,
 			},
 		},
 		{
 			EventSeat: model.EventSeats{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				Booked:       false,
 				BlockedUntil: nil,
 				UserID:       nil,
-				EventID:      eventId,
-				SeatID:       utils.NewUUID(),
+				EventID:      *eventId,
+				SeatID:       myid.New(),
 			},
 			Seat: model.Seats{
-				ID:             utils.NewUUID(),
+				ID:             myid.New(),
 				RowNr:          1,
 				ColumnNr:       2,
-				SeatCategoryID: utils.NewUUID(),
+				SeatCategoryID: myid.New(),
 			},
 			SeatCategory: model.SeatCategories{
-				ID:           utils.NewUUID(),
+				ID:           myid.New(),
 				CategoryName: "standard",
 			},
 			EventSeatCategory: model.EventSeatCategories{
-				EventID:        eventId,
-				SeatCategoryID: utils.NewUUID(),
+				EventID:        *eventId,
+				SeatCategoryID: myid.New(),
 				Price:          100,
 			},
 		},

--- a/src/samples/movie_samples.go
+++ b/src/samples/movie_samples.go
@@ -6,21 +6,20 @@ import (
 
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 func GetSampleMovies() *[]model.Movies {
 	modelMovies := []model.Movies{}
-	uuid1 := uuid.New()
-	uuid2 := uuid.New()
+	uuid1 := myid.New()
+	uuid2 := myid.New()
 	banner := ""
 	cover := ""
 	trailer := ""
 	rating := 5.0
 
 	modelMovies = append(modelMovies, model.Movies{
-		ID:           &uuid1,
+		ID:           uuid1,
 		Title:        "Test Movie 1",
 		Description:  "Test Description 1",
 		BannerPicURL: &banner,
@@ -33,7 +32,7 @@ func GetSampleMovies() *[]model.Movies {
 	})
 
 	modelMovies = append(modelMovies, model.Movies{
-		ID:           &uuid2,
+		ID:           uuid2,
 		Title:        "Test Movie 2",
 		Description:  "Test Description 2",
 		BannerPicURL: &banner,
@@ -50,7 +49,7 @@ func GetSampleMovies() *[]model.Movies {
 
 func GetSampleMovieById() *model.Movies {
 	modelMovies := model.Movies{}
-	uuid1, err := uuid.Parse("6ba7b826-9dad-11d1-80b4-00c04fd430c0")
+	uuid1, err := myid.Parse("6ba7b826-9dad-11d1-80b4-00c04fd430c0")
 	if err != nil {
 		log.Print("GetSampleMovieById: Parsing UUID does not work")
 	}
@@ -60,7 +59,7 @@ func GetSampleMovieById() *model.Movies {
 	rating := 5.0
 
 	modelMovies = model.Movies{
-		ID:           &uuid1,
+		ID:           uuid1,
 		Title:        "Test Movie 1",
 		Description:  "Test Description 1",
 		BannerPicURL: &banner,
@@ -77,16 +76,16 @@ func GetSampleMovieById() *model.Movies {
 
 func GetSampleGenres() *[]model.Genres {
 	modelGenres := []model.Genres{}
-	uuid1 := uuid.New()
-	uuid2 := uuid.New()
+	uuid1 := myid.New()
+	uuid2 := myid.New()
 
 	modelGenres = append(modelGenres, model.Genres{
-		ID:        &uuid1,
+		ID:        uuid1,
 		GenreName: "Action",
 	})
 
 	modelGenres = append(modelGenres, model.Genres{
-		ID:        &uuid2,
+		ID:        uuid2,
 		GenreName: "Drama",
 	})
 
@@ -95,10 +94,10 @@ func GetSampleGenres() *[]model.Genres {
 
 func GetSampleGenre() *model.Genres {
 	modelGenres := model.Genres{}
-	uuid1 := uuid.MustParse("6ba7b820-9dad-11d1-80b4-00c04fd430c4")
+	uuid1 := myid.MustParse("6ba7b820-9dad-11d1-80b4-00c04fd430c4")
 
 	modelGenres = model.Genres{
-		ID:        &uuid1,
+		ID:        uuid1,
 		GenreName: "Action",
 	}
 
@@ -108,9 +107,9 @@ func GetSampleGenre() *model.Genres {
 func GetSampleMovieByIdWithGenre() *models.MovieWithGenres {
 	movieWithGenre := models.MovieWithGenres{}
 
-	uuid1 := uuid.MustParse("6ba7b827-9dad-11d1-80b4-00c04fd430c1")
-	uuid2 := uuid.MustParse("6ba7b820-9dad-11d1-80b4-00c04fd430c4")
-	uuid3 := uuid.MustParse("6ba7b821-9dad-11d1-80b4-00c04fd430c5")
+	uuid1 := myid.MustParse("6ba7b827-9dad-11d1-80b4-00c04fd430c1")
+	uuid2 := myid.MustParse("6ba7b820-9dad-11d1-80b4-00c04fd430c4")
+	uuid3 := myid.MustParse("6ba7b821-9dad-11d1-80b4-00c04fd430c5")
 
 	banner := ""
 	cover := ""
@@ -119,7 +118,7 @@ func GetSampleMovieByIdWithGenre() *models.MovieWithGenres {
 
 	movieWithGenre = models.MovieWithGenres{
 		Movies: model.Movies{
-			ID:           &uuid1,
+			ID:           uuid1,
 			Title:        "Test Movie 1",
 			Description:  "Test Description 1",
 			BannerPicURL: &banner,
@@ -135,13 +134,13 @@ func GetSampleMovieByIdWithGenre() *models.MovieWithGenres {
 		}{
 			{
 				model.Genres{
-					ID:        &uuid2,
+					ID:        uuid2,
 					GenreName: "Action",
 				},
 			},
 			{
 				model.Genres{
-					ID:        &uuid3,
+					ID:        uuid3,
 					GenreName: "Drama",
 				},
 			},
@@ -155,9 +154,9 @@ func GetSampleMovieByIdWithGenre() *models.MovieWithGenres {
 func GetSampleGenreByNameWithMovies() *models.GenreWithMovies {
 	genreByNameWithMovies := models.GenreWithMovies{}
 
-	uuid1 := uuid.MustParse("6ba7b820-9dad-11d1-80b4-00c04fd430c4")
-	uuid2 := uuid.MustParse("6ba7b827-9dad-11d1-80b4-00c04fd430c1")
-	uuid3 := uuid.MustParse("6ba7b828-9dad-11d1-80b4-00c04fd430c2")
+	uuid1 := myid.MustParse("6ba7b820-9dad-11d1-80b4-00c04fd430c4")
+	uuid2 := myid.MustParse("6ba7b827-9dad-11d1-80b4-00c04fd430c1")
+	uuid3 := myid.MustParse("6ba7b828-9dad-11d1-80b4-00c04fd430c2")
 	banner := ""
 	cover := ""
 	trailer := ""
@@ -165,7 +164,7 @@ func GetSampleGenreByNameWithMovies() *models.GenreWithMovies {
 
 	genreByNameWithMovies = models.GenreWithMovies{
 		Genres: model.Genres{
-			ID:        &uuid1,
+			ID:        uuid1,
 			GenreName: "Action",
 		},
 		Movies: []struct {
@@ -173,7 +172,7 @@ func GetSampleGenreByNameWithMovies() *models.GenreWithMovies {
 		}{
 			{
 				model.Movies{
-					ID:           &uuid2,
+					ID:           uuid2,
 					Title:        "Test Movie 1",
 					Description:  "Test Description 1",
 					BannerPicURL: &banner,
@@ -187,7 +186,7 @@ func GetSampleGenreByNameWithMovies() *models.GenreWithMovies {
 			},
 			{
 				model.Movies{
-					ID:           &uuid3,
+					ID:           uuid3,
 					Title:        "Test Movie 2",
 					Description:  "Test Description 2",
 					BannerPicURL: &banner,
@@ -208,12 +207,12 @@ func GetSampleGenreByNameWithMovies() *models.GenreWithMovies {
 func GetSampleGenresWithMovies() *[]models.GenreWithMovies {
 	genresWithMovies := []models.GenreWithMovies{}
 
-	uuid1 := uuid.MustParse("6ba7b820-9dad-11d1-80b4-00c04fd430c4")
-	uuid2 := uuid.MustParse("6ba7b827-9dad-11d1-80b4-00c04fd430c1")
-	uuid3 := uuid.MustParse("6ba7b828-9dad-11d1-80b4-00c04fd430c2")
-	uuid4 := uuid.MustParse("6ba7b821-9dad-11d1-80b4-00c04fd430c5")
-	uuid5 := uuid.MustParse("6ba7b829-9dad-11d1-80b4-00c04fd430c3")
-	uuid6 := uuid.MustParse("6ba7b82a-9dad-11d1-80b4-00c04fd430c4")
+	uuid1 := myid.MustParse("6ba7b820-9dad-11d1-80b4-00c04fd430c4")
+	uuid2 := myid.MustParse("6ba7b827-9dad-11d1-80b4-00c04fd430c1")
+	uuid3 := myid.MustParse("6ba7b828-9dad-11d1-80b4-00c04fd430c2")
+	uuid4 := myid.MustParse("6ba7b821-9dad-11d1-80b4-00c04fd430c5")
+	uuid5 := myid.MustParse("6ba7b829-9dad-11d1-80b4-00c04fd430c3")
+	uuid6 := myid.MustParse("6ba7b82a-9dad-11d1-80b4-00c04fd430c4")
 	banner := ""
 	cover := ""
 	trailer := ""
@@ -221,7 +220,7 @@ func GetSampleGenresWithMovies() *[]models.GenreWithMovies {
 
 	genresWithMovies = append(genresWithMovies, models.GenreWithMovies{
 		Genres: model.Genres{
-			ID:        &uuid1,
+			ID:        uuid1,
 			GenreName: "Action",
 		},
 		Movies: []struct {
@@ -229,7 +228,7 @@ func GetSampleGenresWithMovies() *[]models.GenreWithMovies {
 		}{
 			{
 				model.Movies{
-					ID:           &uuid2,
+					ID:           uuid2,
 					Title:        "Test Movie 1",
 					Description:  "Test Description 1",
 					BannerPicURL: &banner,
@@ -243,7 +242,7 @@ func GetSampleGenresWithMovies() *[]models.GenreWithMovies {
 			},
 			{
 				model.Movies{
-					ID:           &uuid3,
+					ID:           uuid3,
 					Title:        "Test Movie 2",
 					Description:  "Test Description 2",
 					BannerPicURL: &banner,
@@ -260,7 +259,7 @@ func GetSampleGenresWithMovies() *[]models.GenreWithMovies {
 
 	genresWithMovies = append(genresWithMovies, models.GenreWithMovies{
 		Genres: model.Genres{
-			ID:        &uuid4,
+			ID:        uuid4,
 			GenreName: "Drama",
 		},
 		Movies: []struct {
@@ -268,7 +267,7 @@ func GetSampleGenresWithMovies() *[]models.GenreWithMovies {
 		}{
 			{
 				model.Movies{
-					ID:           &uuid5,
+					ID:           uuid5,
 					Title:        "Test Movie 3",
 					Description:  "Test Description 3",
 					BannerPicURL: &banner,
@@ -282,7 +281,7 @@ func GetSampleGenresWithMovies() *[]models.GenreWithMovies {
 			},
 			{
 				model.Movies{
-					ID:           &uuid6,
+					ID:           uuid6,
 					Title:        "Test Movie 4",
 					Description:  "Test Description 4",
 					BannerPicURL: &banner,
@@ -303,10 +302,10 @@ func GetSampleGenresWithMovies() *[]models.GenreWithMovies {
 func GetSampleMoviesWithGenres() *[]models.MovieWithGenres {
 	movieWithGenres := []models.MovieWithGenres{}
 
-	uuid1 := uuid.MustParse("6ba7b820-9dad-11d1-80b4-00c04fd430c4")
-	uuid2 := uuid.MustParse("6ba7b827-9dad-11d1-80b4-00c04fd430c1")
-	uuid3 := uuid.MustParse("6ba7b828-9dad-11d1-80b4-00c04fd430c2")
-	uuid4 := uuid.MustParse("6ba7b821-9dad-11d1-80b4-00c04fd430c5")
+	uuid1 := myid.MustParse("6ba7b820-9dad-11d1-80b4-00c04fd430c4")
+	uuid2 := myid.MustParse("6ba7b827-9dad-11d1-80b4-00c04fd430c1")
+	uuid3 := myid.MustParse("6ba7b828-9dad-11d1-80b4-00c04fd430c2")
+	uuid4 := myid.MustParse("6ba7b821-9dad-11d1-80b4-00c04fd430c5")
 	banner := ""
 	cover := ""
 	trailer := ""
@@ -314,7 +313,7 @@ func GetSampleMoviesWithGenres() *[]models.MovieWithGenres {
 
 	movieWithGenres = append(movieWithGenres, models.MovieWithGenres{
 		Movies: model.Movies{
-			ID:           &uuid1,
+			ID:           uuid1,
 			Title:        "Test Movie 1",
 			Description:  "Test Description 1",
 			BannerPicURL: &banner,
@@ -330,13 +329,13 @@ func GetSampleMoviesWithGenres() *[]models.MovieWithGenres {
 		}{
 			{
 				model.Genres{
-					ID:        &uuid2,
+					ID:        uuid2,
 					GenreName: "Action",
 				},
 			},
 			{
 				model.Genres{
-					ID:        &uuid3,
+					ID:        uuid3,
 					GenreName: "Drama",
 				},
 			},
@@ -345,7 +344,7 @@ func GetSampleMoviesWithGenres() *[]models.MovieWithGenres {
 
 	movieWithGenres = append(movieWithGenres, models.MovieWithGenres{
 		Movies: model.Movies{
-			ID:           &uuid4,
+			ID:           uuid4,
 			Title:        "Test Movie 2",
 			Description:  "Test Description 2",
 			BannerPicURL: &banner,
@@ -361,7 +360,7 @@ func GetSampleMoviesWithGenres() *[]models.MovieWithGenres {
 		}{
 			{
 				model.Genres{
-					ID:        &uuid3,
+					ID:        uuid3,
 					GenreName: "Drama",
 				},
 			},
@@ -374,8 +373,8 @@ func GetSampleMoviesWithGenres() *[]models.MovieWithGenres {
 func GetSampleMovieByIdWithEverything() *models.MovieWithEverything {
 	movieWithEverything := models.MovieWithEverything{}
 
-	// uuid1 := uuid.MustParse("6ba7b820-9dad-11d1-80b4-00c04fd430c4")
-	movieId := utils.NewUUID()
+	// uuid1 := myid.MustParse("6ba7b820-9dad-11d1-80b4-00c04fd430c4")
+	movieId := myid.NewUUID()
 
 	banner := ""
 	cover := ""
@@ -385,7 +384,7 @@ func GetSampleMovieByIdWithEverything() *models.MovieWithEverything {
 
 	movieWithEverything = models.MovieWithEverything{
 		Movies: model.Movies{
-			ID:           movieId,
+			ID:           *movieId,
 			Title:        "Test Movie 1",
 			Description:  "Test Description 1",
 			BannerPicURL: &banner,
@@ -401,7 +400,7 @@ func GetSampleMovieByIdWithEverything() *models.MovieWithEverything {
 		}{
 			{
 				model.Genres{
-					ID:        utils.NewUUID(),
+					ID:        myid.New(),
 					GenreName: "Action",
 				},
 			},
@@ -411,7 +410,7 @@ func GetSampleMovieByIdWithEverything() *models.MovieWithEverything {
 		}{
 			{
 				model.Actors{
-					ID:          utils.NewUUID(),
+					ID:          myid.New(),
 					Name:        "MaxActor Mustermann",
 					Birthdate:   time.Now(),
 					Description: "This is a description",
@@ -423,7 +422,7 @@ func GetSampleMovieByIdWithEverything() *models.MovieWithEverything {
 		}{
 			{
 				model.Producers{
-					ID:          utils.NewUUID(),
+					ID:          myid.New(),
 					Name:        "MaxProducer Mustermann",
 					Birthdate:   time.Now(),
 					Description: "This is a description",
@@ -437,13 +436,13 @@ func GetSampleMovieByIdWithEverything() *models.MovieWithEverything {
 		}{
 			{
 				Review: model.Reviews{
-					ID:        utils.NewUUID(),
+					ID:        myid.New(),
 					Rating:    4.0,
 					Comment:   "This is a comment",
 					Datetime:  time.Now(),
 					IsSpoiler: &isSpoiler,
-					UserID:    utils.NewUUID(),
-					MovieID:   movieId,
+					UserID:    myid.New(),
+					MovieID:   *movieId,
 				},
 				Username: "Max Mustermann",
 			},
@@ -456,10 +455,10 @@ func GetSampleMovieByIdWithEverything() *models.MovieWithEverything {
 func GetSampleMovieDTOCreate() *models.MovieDTOCreate {
 	movieDTO := models.MovieDTOCreate{}
 
-	uuid1 := uuid.MustParse("6ba7b820-9dad-11d1-80b4-00c04fd430c4")
-	uuid2 := uuid.MustParse("6ba7b827-9dad-11d1-80b4-00c04fd430c1")
-	uuid5 := uuid.MustParse("6ba7b829-9dad-11d1-80b4-00c04fd430c3")
-	uuid7 := uuid.MustParse("6ba7b82b-9dad-11d1-80b4-00c04fd430c5")
+	uuid1 := myid.MustParse("6ba7b820-9dad-11d1-80b4-00c04fd430c4")
+	uuid2 := myid.MustParse("6ba7b827-9dad-11d1-80b4-00c04fd430c1")
+	uuid5 := myid.MustParse("6ba7b829-9dad-11d1-80b4-00c04fd430c3")
+	uuid7 := myid.MustParse("6ba7b82b-9dad-11d1-80b4-00c04fd430c5")
 
 	banner := ""
 	cover := ""
@@ -468,7 +467,7 @@ func GetSampleMovieDTOCreate() *models.MovieDTOCreate {
 
 	movieDTO = models.MovieDTOCreate{
 		Movies: model.Movies{
-			ID:           &uuid1,
+			ID:           uuid1,
 			Title:        "Test Movie 1",
 			Description:  "Test Description 1",
 			BannerPicURL: &banner,
@@ -480,21 +479,21 @@ func GetSampleMovieDTOCreate() *models.MovieDTOCreate {
 			Fsk:          18,
 		},
 		GenresID: []struct {
-			ID *uuid.UUID
+			ID *myid.UUID
 		}{
 			{
 				ID: &uuid2,
 			},
 		},
 		ActorsID: []struct {
-			ID *uuid.UUID
+			ID *myid.UUID
 		}{
 			{
 				ID: &uuid5,
 			},
 		},
 		ProducersID: []struct {
-			ID *uuid.UUID
+			ID *myid.UUID
 		}{
 			{
 				ID: &uuid7,

--- a/src/samples/order_samples.go
+++ b/src/samples/order_samples.go
@@ -3,24 +3,23 @@ package samples
 import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
-func GetOrder(priceCategories *[]model.PriceCategories, eventSeats *[]models.GetSlectedSeatsDTO, paymentMethodId *uuid.UUID) *models.CreateOrderDTO {
+func GetOrder(priceCategories *[]model.PriceCategories, eventSeats *[]models.GetSlectedSeatsDTO, paymentMethodId *myid.UUID) *models.CreateOrderDTO {
 
 	return &models.CreateOrderDTO{
 		EventSeatPriceCategories: []struct {
-			EventSeatId     *uuid.UUID
-			PriceCategoryId *uuid.UUID
+			EventSeatId     *myid.UUID
+			PriceCategoryId *myid.UUID
 		}{
 			{
-				EventSeatId:     (*eventSeats)[0].EventSeat.ID,
-				PriceCategoryId: (*priceCategories)[0].ID,
+				EventSeatId:     &(*eventSeats)[0].EventSeat.ID,
+				PriceCategoryId: &(*priceCategories)[0].ID,
 			},
 			{
-				EventSeatId:     (*eventSeats)[1].EventSeat.ID,
-				PriceCategoryId: (*priceCategories)[1].ID,
+				EventSeatId:     &(*eventSeats)[1].EventSeat.ID,
+				PriceCategoryId: &(*priceCategories)[1].ID,
 			},
 		},
 		PaymentMethodID: paymentMethodId,
@@ -30,12 +29,12 @@ func GetOrder(priceCategories *[]model.PriceCategories, eventSeats *[]models.Get
 func GetOrderDTO() *models.CreateOrderDTO {
 	return &models.CreateOrderDTO{
 		EventSeatPriceCategories: []struct {
-			EventSeatId     *uuid.UUID
-			PriceCategoryId *uuid.UUID
+			EventSeatId     *myid.UUID
+			PriceCategoryId *myid.UUID
 		}{
 			{
-				EventSeatId:     utils.NewUUID(),
-				PriceCategoryId: utils.NewUUID(),
+				EventSeatId:     myid.NewUUID(),
+				PriceCategoryId: myid.NewUUID(),
 			},
 		},
 		PaymentMethodID: nil,
@@ -43,8 +42,8 @@ func GetOrderDTO() *models.CreateOrderDTO {
 }
 
 func GetGetOrderDto() *[]models.GetOrderDTO {
-	orderId := utils.NewUUID()
-	order2Id := utils.NewUUID()
+	orderId := myid.New()
+	order2Id := myid.New()
 
 	return &[]models.GetOrderDTO{
 		{
@@ -59,11 +58,11 @@ func GetGetOrderDto() *[]models.GetOrderDTO {
 			}{
 				{
 					Ticket: model.Tickets{
-						ID:      utils.NewUUID(),
+						ID:      myid.New(),
 						OrderID: orderId,
 					},
 					Seat: model.Seats{
-						ID: utils.NewUUID(),
+						ID: myid.New(),
 					},
 				},
 			},
@@ -80,11 +79,11 @@ func GetGetOrderDto() *[]models.GetOrderDTO {
 			}{
 				{
 					Ticket: model.Tickets{
-						ID:      utils.NewUUID(),
+						ID:      myid.New(),
 						OrderID: order2Id,
 					},
 					Seat: model.Seats{
-						ID: utils.NewUUID(),
+						ID: myid.New(),
 					},
 				},
 			},
@@ -94,10 +93,10 @@ func GetGetOrderDto() *[]models.GetOrderDTO {
 
 func GetModelOrder() *model.Orders {
 	return &model.Orders{
-		ID:              utils.NewUUID(),
+		ID:              myid.New(),
 		Totalprice:      100,
 		IsPaid:          false,
-		PaymentMethodID: utils.NewUUID(),
-		UserID:          utils.NewUUID(),
+		PaymentMethodID: myid.NewUUID(),
+		UserID:          myid.New(),
 	}
 }

--- a/src/samples/pricecategories_samples.go
+++ b/src/samples/pricecategories_samples.go
@@ -2,24 +2,24 @@ package samples
 
 import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
 )
 
 func GetPriceCategories() *[]model.PriceCategories {
 	return &[]model.PriceCategories{
 		{
-			ID:           utils.NewUUID(),
+			ID:           myid.New(),
 			CategoryName: utils.ADULT.String(),
 			Price:        0,
 		},
 		{
-			ID:           utils.NewUUID(),
+			ID:           myid.New(),
 			CategoryName: utils.CHILDREN.String(),
 			Price:        10,
 		},
 		{
-			ID:           utils.NewUUID(),
+			ID:           myid.New(),
 			CategoryName: utils.SENIOR.String(),
 			Price:        5,
 		},
@@ -29,17 +29,17 @@ func GetPriceCategories() *[]model.PriceCategories {
 func GetSamplePriceCategories() *[]model.PriceCategories {
 	priceCategories := []model.PriceCategories{}
 
-	uuid1 := uuid.New()
-	uuid2 := uuid.New()
+	uuid1 := myid.New()
+	uuid2 := myid.New()
 
 	priceCategories = append(priceCategories, model.PriceCategories{
-		ID:           &uuid1,
+		ID:           uuid1,
 		CategoryName: "StudentDiscount",
 		Price:        1000,
 	})
 
 	priceCategories = append(priceCategories, model.PriceCategories{
-		ID:           &uuid2,
+		ID:           uuid2,
 		CategoryName: "regular_price",
 		Price:        500,
 	})
@@ -50,14 +50,13 @@ func GetSamplePriceCategories() *[]model.PriceCategories {
 func GetSamplePriceCategory() *model.PriceCategories {
 	priceCategory := model.PriceCategories{}
 
-	uuid1 := uuid.MustParse("6ba7b820-9dad-11d1-80b4-00c04fd430c4")
+	uuid1 := myid.MustParse("6ba7b820-9dad-11d1-80b4-00c04fd430c4")
 
 	priceCategory = model.PriceCategories{
-		ID:           &uuid1,
+		ID:           uuid1,
 		CategoryName: "StudentDiscount",
 		Price:        1000,
 	}
 
 	return &priceCategory
 }
-

--- a/src/samples/review_samples.go
+++ b/src/samples/review_samples.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 func GetSampleReviewRequest() models.CreateReviewRequest {
@@ -20,17 +20,17 @@ func GetSampleReviewRequest() models.CreateReviewRequest {
 }
 
 func GetSampleReview() model.Reviews {
-	id := uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")
-	movieId := uuid.MustParse("db30d28d-506a-4637-9e9e-aef1546f9cdc")
-	userId := uuid.MustParse("47cf7525-01df-45b7-a3a9-d3cb25ae939f")
+	id := myid.MustParse("123e4567-e89b-12d3-a456-426614174000")
+	movieId := myid.MustParse("db30d28d-506a-4637-9e9e-aef1546f9cdc")
+	userId := myid.MustParse("47cf7525-01df-45b7-a3a9-d3cb25ae939f")
 	datetime, _ := time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
 	return model.Reviews{
-		ID:        &id,
+		ID:        id,
 		Rating:    5,
 		Comment:   "Comment",
 		Datetime:  datetime,
 		IsSpoiler: new(bool),
-		MovieID:   &movieId,
-		UserID:    &userId,
+		MovieID:   movieId,
+		UserID:    userId,
 	}
 }

--- a/src/samples/theatre_samples.go
+++ b/src/samples/theatre_samples.go
@@ -3,8 +3,8 @@ package samples
 import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/utils"
-	"github.com/google/uuid"
 )
 
 const (
@@ -18,9 +18,9 @@ const (
 )
 
 func GetSampleAddress() model.Addresses {
-	id := uuid.MustParse(addressId)
+	id := myid.MustParse(addressId)
 	return model.Addresses{
-		ID:       &id,
+		ID:       id,
 		Street:   "Street",
 		StreetNr: "StreetNr",
 		Zipcode:  "Zipcode",
@@ -32,29 +32,29 @@ func GetSampleAddress() model.Addresses {
 func GetSampleTheatres() []model.Theatres {
 	return []model.Theatres{
 		{
-			ID:        utils.NewUUID(),
+			ID:        myid.New(),
 			Name:      "Theatre1",
 			LogoURL:   utils.GetStringPointer("LogoUr1"),
-			AddressID: utils.NewUUID(),
+			AddressID: myid.New(),
 		},
 		{
-			ID:        utils.NewUUID(),
+			ID:        myid.New(),
 			Name:      "Theatre2",
 			LogoURL:   utils.GetStringPointer("LogoUrl2"),
-			AddressID: utils.NewUUID(),
+			AddressID: myid.New(),
 		},
 	}
 }
 
 func GetSampleTheatre() model.Theatres {
-	id := uuid.MustParse(theatreId)
-	addressId := uuid.MustParse(addressId)
+	id := myid.MustParse(theatreId)
+	addressId := myid.MustParse(addressId)
 	logoUrl := "LogoURL"
 	return model.Theatres{
-		ID:        &id,
+		ID:        id,
 		Name:      "Theatre",
 		LogoURL:   &logoUrl,
-		AddressID: &addressId,
+		AddressID: addressId,
 	}
 }
 
@@ -81,7 +81,7 @@ func GetSampleTheatreCreate() models.CreateTheatreRequest {
 }
 
 func GetSampleCreateCinemaHallRequest() models.CreateCinemaHallRequest {
-	theatreId := uuid.MustParse(theatreId)
+	theatreId := myid.MustParse(theatreId)
 	return models.CreateCinemaHallRequest{
 		HallName: "HallName",
 		Seats: [][]struct {
@@ -2215,28 +2215,28 @@ func GetSampleCreateCinemaHallRequestInvalidDoubleSeats() models.CreateCinemaHal
 }
 
 func GetSampleCinemaHall() model.CinemaHalls {
-	id := uuid.MustParse(cinemaHallId)
-	theatreId := uuid.MustParse(theatreId)
+	id := myid.MustParse(cinemaHallId)
+	theatreId := myid.MustParse(theatreId)
 	return model.CinemaHalls{
-		ID:        &id,
+		ID:        id,
 		Name:      "HallName",
 		Capacity:  23 * 14,
-		TheatreID: &theatreId,
+		TheatreID: theatreId,
 	}
 }
 
 func GetSampleCinemaHalls() []model.CinemaHalls {
-	theatreId := uuid.MustParse(theatreId)
+	theatreId := myid.MustParse(theatreId)
 	return []model.CinemaHalls{
 		{
-			ID:        utils.NewUUID(),
-			TheatreID: &theatreId,
+			ID:        myid.New(),
+			TheatreID: theatreId,
 			Name:      "Hall 1",
 			Capacity:  100,
 		},
 		{
-			ID:        utils.NewUUID(),
-			TheatreID: &theatreId,
+			ID:        myid.New(),
+			TheatreID: theatreId,
 			Name:      "Hall 2",
 			Capacity:  200,
 		},
@@ -2244,33 +2244,33 @@ func GetSampleCinemaHalls() []model.CinemaHalls {
 }
 
 func GetSampleSeat() model.Seats {
-	id := uuid.MustParse(seatId)
-	cinemaHallId := uuid.MustParse(cinemaHallId)
-	seatCategoryId := uuid.MustParse(seatCategoryId1)
+	id := myid.MustParse(seatId)
+	cinemaHallId := myid.MustParse(cinemaHallId)
+	seatCategoryId := myid.MustParse(seatCategoryId1)
 	return model.Seats{
-		ID:             &id,
+		ID:             id,
 		ColumnNr:       0,
 		RowNr:          0,
-		CinemaHallID:   &cinemaHallId,
-		SeatCategoryID: &seatCategoryId,
+		CinemaHallID:   cinemaHallId,
+		SeatCategoryID: seatCategoryId,
 	}
 }
 
 func GetSampleSeatCategories() []model.SeatCategories {
-	seatCategoryId1 := uuid.MustParse(seatCategoryId1)
-	seatCategoryId2 := uuid.MustParse(seatCategoryId2)
-	seatCategoryId3 := uuid.MustParse(seatCategoryId3)
+	seatCategoryId1 := myid.MustParse(seatCategoryId1)
+	seatCategoryId2 := myid.MustParse(seatCategoryId2)
+	seatCategoryId3 := myid.MustParse(seatCategoryId3)
 	return []model.SeatCategories{
 		{
-			ID:           &seatCategoryId1,
+			ID:           seatCategoryId1,
 			CategoryName: "regular",
 		},
 		{
-			ID:           &seatCategoryId2,
+			ID:           seatCategoryId2,
 			CategoryName: "loge",
 		},
 		{
-			ID:           &seatCategoryId3,
+			ID:           seatCategoryId3,
 			CategoryName: "vip",
 		},
 	}

--- a/src/samples/ticket_samples.go
+++ b/src/samples/ticket_samples.go
@@ -5,20 +5,20 @@ import (
 
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 func GetSampleTicket() *models.TicketDTO {
 	ticket := models.TicketDTO{}
 
-	id := uuid.MustParse("b1fd6028-4421-4d24-9cb1-b4fb84f180f9")
-	seatId := uuid.MustParse("ac78c852-9b7d-4f08-996e-d606a54d4f38")
-	eventId := uuid.MustParse("7ef0b48d-0696-4269-a713-1dfaed8f3249")
-	orderId := uuid.MustParse("94c917a5-45e1-4550-be40-3a2de4688951")
-	cinemaHallId := uuid.MustParse("11eea0aa-cf4c-b23c-bc67-0242ac120003")
-	userId := uuid.MustParse("25c666f0-ee2b-42e1-854b-fde3c412d758")
-	paymentMethodId := uuid.MustParse("d0c71fb8-f08c-4957-90f2-95fabcdadc45")
-	seatCategoryId := uuid.MustParse("ec33b774-7e96-4428-818c-8cad0827dee0")
+	id := myid.MustParse("b1fd6028-4421-4d24-9cb1-b4fb84f180f9")
+	seatId := myid.MustParse("ac78c852-9b7d-4f08-996e-d606a54d4f38")
+	eventId := myid.MustParse("7ef0b48d-0696-4269-a713-1dfaed8f3249")
+	orderId := myid.MustParse("94c917a5-45e1-4550-be40-3a2de4688951")
+	cinemaHallId := myid.MustParse("11eea0aa-cf4c-b23c-bc67-0242ac120003")
+	userId := myid.MustParse("25c666f0-ee2b-42e1-854b-fde3c412d758")
+	paymentMethodId := myid.MustParse("d0c71fb8-f08c-4957-90f2-95fabcdadc45")
+	seatCategoryId := myid.MustParse("ec33b774-7e96-4428-818c-8cad0827dee0")
 	description := "Test Description"
 
 	timeStart, _ := time.Parse("2006-01-02T15:04:05.999999-07:00", "2023-12-31T10:52:24.108196+01:00")
@@ -29,30 +29,30 @@ func GetSampleTicket() *models.TicketDTO {
 		Validated: *new(bool),
 		Price:     10,
 		Seats: &model.Seats{
-			ID:              &seatId,
+			ID:              seatId,
 			RowNr:           1,
 			ColumnNr:        1,
 			VisibleRowNr:    1,
 			VisibleColumnNr: 1,
-			SeatCategoryID:  &seatCategoryId,
-			CinemaHallID:    &cinemaHallId,
+			SeatCategoryID:  seatCategoryId,
+			CinemaHallID:    cinemaHallId,
 			Type:            "Test Type",
 		},
 		Event: &model.Events{
-			ID:           &eventId,
+			ID:           eventId,
 			Title:        "Test Event",
 			Start:        timeStart,
 			End:          timeEnd,
 			Description:  &description,
 			EventType:    "Test EventType",
-			CinemaHallID: &cinemaHallId,
+			CinemaHallID: cinemaHallId,
 		},
 		Order: &model.Orders{
-			ID:              &orderId,
+			ID:              orderId,
 			Totalprice:      1000,
 			IsPaid:          false,
 			PaymentMethodID: &paymentMethodId,
-			UserID:          &userId,
+			UserID:          userId,
 		},
 	}
 
@@ -62,18 +62,18 @@ func GetSampleTicket() *models.TicketDTO {
 func GetSampleCreateTicket() *model.Tickets {
 	ticket := model.Tickets{}
 
-	id := uuid.New()
-	eventSeatId := uuid.New()
-	priceCategoryID := uuid.New()
-	orderId := uuid.New()
+	id := myid.New()
+	eventSeatId := myid.New()
+	priceCategoryID := myid.New()
+	orderId := myid.New()
 
 	ticket = model.Tickets{
-		ID:              &id,
+		ID:              id,
 		Validated:       *new(bool),
 		Price:           10,
-		OrderID:         &orderId,
-		PriceCategoryID: &priceCategoryID,
-		EventSeatID:     &eventSeatId,
+		OrderID:         orderId,
+		PriceCategoryID: priceCategoryID,
+		EventSeatID:     eventSeatId,
 	}
 
 	return &ticket

--- a/src/samples/user_samples.go
+++ b/src/samples/user_samples.go
@@ -3,7 +3,7 @@ package samples
 import (
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
-	"github.com/google/uuid"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 )
 
 func GetSampleRegistrationData() models.RegistrationRequest {
@@ -24,12 +24,12 @@ func GetSampleLoginData() models.LoginRequest {
 }
 
 func GetSampleUser() model.Users {
-	id := uuid.MustParse("47cf7525-01df-45b7-a3a9-d3cb25ae939f")
+	id := myid.MustParse("47cf7525-01df-45b7-a3a9-d3cb25ae939f")
 	username := "Collinho el niño"
 	firstname := "Collin"
 	lastname := "Forslund"
 	return model.Users{
-		ID:        &id,
+		ID:        id,
 		Username:  &username,
 		Email:     "collin.forslund@gmail.com",
 		Password:  "$2a$10$vxXPPpLp5baQ7mzS1pNSEuk6ZW3mbx1Ej7u0tJnF5wferEFqT.qlK",

--- a/src/utils/jetutils.go
+++ b/src/utils/jetutils.go
@@ -5,18 +5,18 @@ import (
 	"time"
 
 	kts_errors "github.com/ELITE-Kinoticketsystem/Backend-KTS/src/errors"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/models"
 	"github.com/go-jet/jet/v2/mysql"
-	"github.com/google/uuid"
 )
 
-func MysqlUuid(uuid *uuid.UUID) mysql.StringExpression {
+func MysqlUuid(uuid myid.UUID) mysql.StringExpression {
 	binary_id, _ := uuid.MarshalBinary()
 	return mysql.String(string(binary_id))
 }
 
-func MysqlUuidOrNil(uuid *uuid.UUID) mysql.Expression {
+func MysqlUuidOrNil(uuid *myid.UUID) mysql.Expression {
 	if uuid == nil {
 		return mysql.NULL
 	}

--- a/src/utils/jwt_utils.go
+++ b/src/utils/jwt_utils.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"time"
 
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/google/uuid"
 )
 
 var key = os.Getenv("JWT_SECRET")
@@ -17,7 +17,7 @@ const refreshTokenLifeSpan = 3 * 24 * 60 * 60 // 3 days
 const leeway = 5 * 60                         // 5 minutes
 const issuer = "KTS"
 
-func GenerateJWT(userId *uuid.UUID) (string, string, error) {
+func GenerateJWT(userId *myid.UUID) (string, string, error) {
 	now := time.Now()
 
 	claims := &jwt.MapClaims{
@@ -50,7 +50,7 @@ func GenerateJWT(userId *uuid.UUID) (string, string, error) {
 	return signedToken, signedRefreshToken, err
 }
 
-func ValidateToken(tokenString string) (*uuid.UUID, error) {
+func ValidateToken(tokenString string) (*myid.UUID, error) {
 	validMethodsOption := jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()})
 	leewayOption := jwt.WithLeeway(time.Duration(leeway) * time.Second)
 	issuerOption := jwt.WithIssuer(issuer)
@@ -71,7 +71,7 @@ func ValidateToken(tokenString string) (*uuid.UUID, error) {
 		return nil, jwt.ErrTokenUnverifiable
 	}
 
-	userId, err := uuid.Parse(claims["sub"].(string))
+	userId, err := myid.Parse(claims["sub"].(string))
 	if err != nil {
 		return nil, err
 	}
@@ -91,9 +91,9 @@ func RefreshTokens(refreshToken string) (string, string, error) {
 func SetJWTCookies(c *gin.Context, token string, refreshToken string) {
 	// for development
 	http.SetCookie(c.Writer, &http.Cookie{
-		Name:     "token",
-		Value:    token,
-		Path:     "/",
+		Name:  "token",
+		Value: token,
+		Path:  "/",
 		/* Domain */
 		MaxAge:   tokenLifespan,
 		Secure:   true,
@@ -102,9 +102,9 @@ func SetJWTCookies(c *gin.Context, token string, refreshToken string) {
 	})
 
 	http.SetCookie(c.Writer, &http.Cookie{
-		Name:     "refreshToken",
-		Value:    refreshToken,
-		Path:     "/",
+		Name:  "refreshToken",
+		Value: refreshToken,
+		Path:  "/",
 		/* Domain */
 		MaxAge:   refreshTokenLifeSpan,
 		Secure:   true,

--- a/src/utils/testutils.go
+++ b/src/utils/testutils.go
@@ -6,9 +6,9 @@ import (
 	"reflect"
 
 	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/gen/KinoTicketSystem/model"
+	"github.com/ELITE-Kinoticketsystem/Backend-KTS/src/myid"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/google/uuid"
 )
 
 // Compare two users while ignoring their ids and hashed passwords.
@@ -56,7 +56,7 @@ type ExceptUuidMatcher struct {
 }
 
 func (m ExceptUuidMatcher) Matches(otherValue interface{}) bool {
-	return cmp.Equal(m.value, otherValue, cmpopts.IgnoreTypes(&uuid.UUID{}))
+	return cmp.Equal(m.value, otherValue, cmpopts.IgnoreTypes(myid.UUID{}))
 }
 
 func (m ExceptUuidMatcher) String() string {
@@ -70,7 +70,7 @@ func EqExceptUUIDs(value interface{}) ExceptUuidMatcher {
 
 // for matching a uuid with its binary representation
 type UUIDMatcher struct {
-	id *uuid.UUID
+	id myid.UUID
 }
 
 func (m UUIDMatcher) Match(v driver.Value) bool {
@@ -78,7 +78,7 @@ func (m UUIDMatcher) Match(v driver.Value) bool {
 	if !ok {
 		return false
 	}
-	id, err := m.id.MarshalBinary()
+	id, err := m.id.UUID.MarshalBinary()
 	if err != nil {
 		return false
 	}
@@ -86,7 +86,7 @@ func (m UUIDMatcher) Match(v driver.Value) bool {
 }
 
 // Returns a matcher that matches the uuid with its binary representation.
-func EqUUID(id *uuid.UUID) UUIDMatcher {
+func EqUUID(id myid.UUID) UUIDMatcher {
 	return UUIDMatcher{id: id}
 }
 

--- a/src/utils/uuidutils.go
+++ b/src/utils/uuidutils.go
@@ -1,6 +1,8 @@
 package utils
 
-import "github.com/google/uuid"
+import (
+	"github.com/google/uuid"
+)
 
 func NewUUID() *uuid.UUID {
 	uuid := uuid.New()

--- a/test.json
+++ b/test.json
@@ -1,0 +1,2106 @@
+{
+    "theatreID": "2FC58A08FAD6495EADB12BE3D07902CA",
+    "hallName": "EliasHall",
+    "seats": [
+        [
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 0,
+                "RowNr": 0
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 1,
+                "RowNr": 0
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 2,
+                "RowNr": 0
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 3,
+                "RowNr": 0
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 4,
+                "RowNr": 0
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 5,
+                "RowNr": 0
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 6,
+                "RowNr": 0
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 7,
+                "RowNr": 0
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 8,
+                "RowNr": 0
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 9,
+                "RowNr": 0
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 10,
+                "RowNr": 0
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 11,
+                "RowNr": 0
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 12,
+                "RowNr": 0
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 13,
+                "RowNr": 0
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 14,
+                "RowNr": 0
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 15,
+                "RowNr": 0
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 16,
+                "RowNr": 0
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 17,
+                "RowNr": 0
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 18,
+                "RowNr": 0
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 19,
+                "RowNr": 0
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 20,
+                "RowNr": 0
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 21,
+                "RowNr": 0
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 22,
+                "RowNr": 0
+            }
+        ],
+        [
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 0,
+                "RowNr": 1
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 1,
+                "RowNr": 1
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 2,
+                "RowNr": 1
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 3,
+                "RowNr": 1
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 4,
+                "RowNr": 1
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 5,
+                "RowNr": 1
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 6,
+                "RowNr": 1
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 7,
+                "RowNr": 1
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 8,
+                "RowNr": 1
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 9,
+                "RowNr": 1
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 10,
+                "RowNr": 1
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 11,
+                "RowNr": 1
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 12,
+                "RowNr": 1
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 13,
+                "RowNr": 1
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 14,
+                "RowNr": 1
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 15,
+                "RowNr": 1
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 16,
+                "RowNr": 1
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 17,
+                "RowNr": 1
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 18,
+                "RowNr": 1
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 19,
+                "RowNr": 1
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 20,
+                "RowNr": 1
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 21,
+                "RowNr": 1
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 22,
+                "RowNr": 1
+            }
+        ],
+        [
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 0,
+                "RowNr": 2
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 1,
+                "RowNr": 2
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 2,
+                "RowNr": 2
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 3,
+                "RowNr": 2
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 4,
+                "RowNr": 2
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 5,
+                "RowNr": 2
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 6,
+                "RowNr": 2
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 7,
+                "RowNr": 2
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 8,
+                "RowNr": 2
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 9,
+                "RowNr": 2
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 10,
+                "RowNr": 2
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 11,
+                "RowNr": 2
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 12,
+                "RowNr": 2
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 13,
+                "RowNr": 2
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 14,
+                "RowNr": 2
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 15,
+                "RowNr": 2
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 16,
+                "RowNr": 2
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 17,
+                "RowNr": 2
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 18,
+                "RowNr": 2
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 19,
+                "RowNr": 2
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 20,
+                "RowNr": 2
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 21,
+                "RowNr": 2
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 22,
+                "RowNr": 2
+            }
+        ],
+        [
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 0,
+                "RowNr": 3
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 1,
+                "RowNr": 3
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 2,
+                "RowNr": 3
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 3,
+                "RowNr": 3
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 4,
+                "RowNr": 3
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 5,
+                "RowNr": 3
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 6,
+                "RowNr": 3
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 7,
+                "RowNr": 3
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 8,
+                "RowNr": 3
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 9,
+                "RowNr": 3
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 10,
+                "RowNr": 3
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 11,
+                "RowNr": 3
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 12,
+                "RowNr": 3
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 13,
+                "RowNr": 3
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 14,
+                "RowNr": 3
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 15,
+                "RowNr": 3
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 16,
+                "RowNr": 3
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 17,
+                "RowNr": 3
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 18,
+                "RowNr": 3
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 19,
+                "RowNr": 3
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 20,
+                "RowNr": 3
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 21,
+                "RowNr": 3
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 22,
+                "RowNr": 3
+            }
+        ],
+        [
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 0,
+                "RowNr": 4
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 1,
+                "RowNr": 4
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 2,
+                "RowNr": 4
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 3,
+                "RowNr": 4
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 4,
+                "RowNr": 4
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 5,
+                "RowNr": 4
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 6,
+                "RowNr": 4
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 7,
+                "RowNr": 4
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 8,
+                "RowNr": 4
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 9,
+                "RowNr": 4
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 10,
+                "RowNr": 4
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 11,
+                "RowNr": 4
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 12,
+                "RowNr": 4
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 13,
+                "RowNr": 4
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 14,
+                "RowNr": 4
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 15,
+                "RowNr": 4
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 16,
+                "RowNr": 4
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 17,
+                "RowNr": 4
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 18,
+                "RowNr": 4
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 19,
+                "RowNr": 4
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 20,
+                "RowNr": 4
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 21,
+                "RowNr": 4
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 22,
+                "RowNr": 4
+            }
+        ],
+        [
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 0,
+                "RowNr": 5
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 1,
+                "RowNr": 5
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 2,
+                "RowNr": 5
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 3,
+                "RowNr": 5
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 4,
+                "RowNr": 5
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 5,
+                "RowNr": 5
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 6,
+                "RowNr": 5
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 7,
+                "RowNr": 5
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 8,
+                "RowNr": 5
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 9,
+                "RowNr": 5
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 10,
+                "RowNr": 5
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 11,
+                "RowNr": 5
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 12,
+                "RowNr": 5
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 13,
+                "RowNr": 5
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 14,
+                "RowNr": 5
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 15,
+                "RowNr": 5
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 16,
+                "RowNr": 5
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 17,
+                "RowNr": 5
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 18,
+                "RowNr": 5
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 19,
+                "RowNr": 5
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 20,
+                "RowNr": 5
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 21,
+                "RowNr": 5
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 22,
+                "RowNr": 5
+            }
+        ],
+        [
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 0,
+                "RowNr": 6
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 1,
+                "RowNr": 6
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 2,
+                "RowNr": 6
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 3,
+                "RowNr": 6
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 4,
+                "RowNr": 6
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 5,
+                "RowNr": 6
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 6,
+                "RowNr": 6
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 7,
+                "RowNr": 6
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 8,
+                "RowNr": 6
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 9,
+                "RowNr": 6
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 10,
+                "RowNr": 6
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 11,
+                "RowNr": 6
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 12,
+                "RowNr": 6
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 13,
+                "RowNr": 6
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 14,
+                "RowNr": 6
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 15,
+                "RowNr": 6
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 16,
+                "RowNr": 6
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 17,
+                "RowNr": 6
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 18,
+                "RowNr": 6
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 19,
+                "RowNr": 6
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 20,
+                "RowNr": 6
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 21,
+                "RowNr": 6
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 22,
+                "RowNr": 6
+            }
+        ],
+        [
+            {
+                "Category": "regular",
+                "Type": "empty",
+                "ColumnNr": 0,
+                "RowNr": 7
+            },
+            {
+                "Category": "regular",
+                "Type": "empty",
+                "ColumnNr": 1,
+                "RowNr": 7
+            },
+            {
+                "Category": "regular",
+                "Type": "empty",
+                "ColumnNr": 2,
+                "RowNr": 7
+            },
+            {
+                "Category": "regular",
+                "Type": "empty",
+                "ColumnNr": 3,
+                "RowNr": 7
+            },
+            {
+                "Category": "regular",
+                "Type": "empty",
+                "ColumnNr": 4,
+                "RowNr": 7
+            },
+            {
+                "Category": "regular",
+                "Type": "empty",
+                "ColumnNr": 5,
+                "RowNr": 7
+            },
+            {
+                "Category": "regular",
+                "Type": "empty",
+                "ColumnNr": 6,
+                "RowNr": 7
+            },
+            {
+                "Category": "regular",
+                "Type": "empty",
+                "ColumnNr": 7,
+                "RowNr": 7
+            },
+            {
+                "Category": "regular",
+                "Type": "empty",
+                "ColumnNr": 8,
+                "RowNr": 7
+            },
+            {
+                "Category": "regular",
+                "Type": "empty",
+                "ColumnNr": 9,
+                "RowNr": 7
+            },
+            {
+                "Category": "regular",
+                "Type": "empty",
+                "ColumnNr": 10,
+                "RowNr": 7
+            },
+            {
+                "Category": "regular",
+                "Type": "empty",
+                "ColumnNr": 11,
+                "RowNr": 7
+            },
+            {
+                "Category": "regular",
+                "Type": "empty",
+                "ColumnNr": 12,
+                "RowNr": 7
+            },
+            {
+                "Category": "regular",
+                "Type": "empty",
+                "ColumnNr": 13,
+                "RowNr": 7
+            },
+            {
+                "Category": "regular",
+                "Type": "empty",
+                "ColumnNr": 14,
+                "RowNr": 7
+            },
+            {
+                "Category": "regular",
+                "Type": "empty",
+                "ColumnNr": 15,
+                "RowNr": 7
+            },
+            {
+                "Category": "regular",
+                "Type": "empty",
+                "ColumnNr": 16,
+                "RowNr": 7
+            },
+            {
+                "Category": "regular",
+                "Type": "empty",
+                "ColumnNr": 17,
+                "RowNr": 7
+            },
+            {
+                "Category": "regular",
+                "Type": "empty",
+                "ColumnNr": 18,
+                "RowNr": 7
+            },
+            {
+                "Category": "regular",
+                "Type": "empty",
+                "ColumnNr": 19,
+                "RowNr": 7
+            },
+            {
+                "Category": "regular",
+                "Type": "empty",
+                "ColumnNr": 20,
+                "RowNr": 7
+            },
+            {
+                "Category": "regular",
+                "Type": "empty",
+                "ColumnNr": 21,
+                "RowNr": 7
+            },
+            {
+                "Category": "regular",
+                "Type": "empty",
+                "ColumnNr": 22,
+                "RowNr": 7
+            }
+        ],
+        [
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 0,
+                "RowNr": 8
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 1,
+                "RowNr": 8
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 2,
+                "RowNr": 8
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 3,
+                "RowNr": 8
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 4,
+                "RowNr": 8
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 5,
+                "RowNr": 8
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 6,
+                "RowNr": 8
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 7,
+                "RowNr": 8
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 8,
+                "RowNr": 8
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 9,
+                "RowNr": 8
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 10,
+                "RowNr": 8
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 11,
+                "RowNr": 8
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 12,
+                "RowNr": 8
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 13,
+                "RowNr": 8
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 14,
+                "RowNr": 8
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 15,
+                "RowNr": 8
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 16,
+                "RowNr": 8
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 17,
+                "RowNr": 8
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 18,
+                "RowNr": 8
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 19,
+                "RowNr": 8
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 20,
+                "RowNr": 8
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 21,
+                "RowNr": 8
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 22,
+                "RowNr": 8
+            }
+        ],
+        [
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 0,
+                "RowNr": 9
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 1,
+                "RowNr": 9
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 2,
+                "RowNr": 9
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 3,
+                "RowNr": 9
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 4,
+                "RowNr": 9
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 5,
+                "RowNr": 9
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 6,
+                "RowNr": 9
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 7,
+                "RowNr": 9
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 8,
+                "RowNr": 9
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 9,
+                "RowNr": 9
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 10,
+                "RowNr": 9
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 11,
+                "RowNr": 9
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 12,
+                "RowNr": 9
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 13,
+                "RowNr": 9
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 14,
+                "RowNr": 9
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 15,
+                "RowNr": 9
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 16,
+                "RowNr": 9
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 17,
+                "RowNr": 9
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 18,
+                "RowNr": 9
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 19,
+                "RowNr": 9
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 20,
+                "RowNr": 9
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 21,
+                "RowNr": 9
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 22,
+                "RowNr": 9
+            }
+        ],
+        [
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 0,
+                "RowNr": 10
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 1,
+                "RowNr": 10
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 2,
+                "RowNr": 10
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 3,
+                "RowNr": 10
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 4,
+                "RowNr": 10
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 5,
+                "RowNr": 10
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 6,
+                "RowNr": 10
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 7,
+                "RowNr": 10
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 8,
+                "RowNr": 10
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 9,
+                "RowNr": 10
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 10,
+                "RowNr": 10
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 11,
+                "RowNr": 10
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 12,
+                "RowNr": 10
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 13,
+                "RowNr": 10
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 14,
+                "RowNr": 10
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 15,
+                "RowNr": 10
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 16,
+                "RowNr": 10
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 17,
+                "RowNr": 10
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 18,
+                "RowNr": 10
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 19,
+                "RowNr": 10
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 20,
+                "RowNr": 10
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 21,
+                "RowNr": 10
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 22,
+                "RowNr": 10
+            }
+        ],
+        [
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 0,
+                "RowNr": 11
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 1,
+                "RowNr": 11
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 2,
+                "RowNr": 11
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 3,
+                "RowNr": 11
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 4,
+                "RowNr": 11
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 5,
+                "RowNr": 11
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 6,
+                "RowNr": 11
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 7,
+                "RowNr": 11
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 8,
+                "RowNr": 11
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 9,
+                "RowNr": 11
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 10,
+                "RowNr": 11
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 11,
+                "RowNr": 11
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 12,
+                "RowNr": 11
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 13,
+                "RowNr": 11
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 14,
+                "RowNr": 11
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 15,
+                "RowNr": 11
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 16,
+                "RowNr": 11
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 17,
+                "RowNr": 11
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 18,
+                "RowNr": 11
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 19,
+                "RowNr": 11
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 20,
+                "RowNr": 11
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 21,
+                "RowNr": 11
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 22,
+                "RowNr": 11
+            }
+        ],
+        [
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 0,
+                "RowNr": 12
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 1,
+                "RowNr": 12
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 2,
+                "RowNr": 12
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 3,
+                "RowNr": 12
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 4,
+                "RowNr": 12
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 5,
+                "RowNr": 12
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 6,
+                "RowNr": 12
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 7,
+                "RowNr": 12
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 8,
+                "RowNr": 12
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 9,
+                "RowNr": 12
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 10,
+                "RowNr": 12
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 11,
+                "RowNr": 12
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 12,
+                "RowNr": 12
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 13,
+                "RowNr": 12
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 14,
+                "RowNr": 12
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 15,
+                "RowNr": 12
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 16,
+                "RowNr": 12
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 17,
+                "RowNr": 12
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 18,
+                "RowNr": 12
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 19,
+                "RowNr": 12
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 20,
+                "RowNr": 12
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 21,
+                "RowNr": 12
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 22,
+                "RowNr": 12
+            }
+        ],
+        [
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 0,
+                "RowNr": 13
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 1,
+                "RowNr": 13
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 2,
+                "RowNr": 13
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 3,
+                "RowNr": 13
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 4,
+                "RowNr": 13
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 5,
+                "RowNr": 13
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 6,
+                "RowNr": 13
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 7,
+                "RowNr": 13
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 8,
+                "RowNr": 13
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 9,
+                "RowNr": 13
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 10,
+                "RowNr": 13
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 11,
+                "RowNr": 13
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 12,
+                "RowNr": 13
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 13,
+                "RowNr": 13
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 14,
+                "RowNr": 13
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 15,
+                "RowNr": 13
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 16,
+                "RowNr": 13
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 17,
+                "RowNr": 13
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 18,
+                "RowNr": 13
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 19,
+                "RowNr": 13
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 20,
+                "RowNr": 13
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 21,
+                "RowNr": 13
+            },
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 22,
+                "RowNr": 13
+            }
+        ],
+        [
+            {
+                "Category": "regular",
+                "Type": "regular",
+                "ColumnNr": 0,
+                "RowNr": 14
+            },
+            {
+                "Category": "regular",
+                "Type": "double",
+                "ColumnNr": 1,
+                "RowNr": 14
+            },
+            {
+                "Category": "regular",
+                "Type": "emptyDouble",
+                "ColumnNr": 2,
+                "RowNr": 14
+            },
+            {
+                "Category": "regular",
+                "Type": "double",
+                "ColumnNr": 3,
+                "RowNr": 14
+            },
+            {
+                "Category": "regular",
+                "Type": "emptyDouble",
+                "ColumnNr": 4,
+                "RowNr": 14
+            },
+            {
+                "Category": "regular",
+                "Type": "double",
+                "ColumnNr": 5,
+                "RowNr": 14
+            },
+            {
+                "Category": "regular",
+                "Type": "emptyDouble",
+                "ColumnNr": 6,
+                "RowNr": 14
+            },
+            {
+                "Category": "regular",
+                "Type": "double",
+                "ColumnNr": 7,
+                "RowNr": 14
+            },
+            {
+                "Category": "regular",
+                "Type": "emptyDouble",
+                "ColumnNr": 8,
+                "RowNr": 14
+            },
+            {
+                "Category": "regular",
+                "Type": "double",
+                "ColumnNr": 9,
+                "RowNr": 14
+            },
+            {
+                "Category": "regular",
+                "Type": "emptyDouble",
+                "ColumnNr": 10,
+                "RowNr": 14
+            },
+            {
+                "Category": "regular",
+                "Type": "double",
+                "ColumnNr": 11,
+                "RowNr": 14
+            },
+            {
+                "Category": "regular",
+                "Type": "emptyDouble",
+                "ColumnNr": 12,
+                "RowNr": 14
+            },
+            {
+                "Category": "regular",
+                "Type": "double",
+                "ColumnNr": 13,
+                "RowNr": 14
+            },
+            {
+                "Category": "regular",
+                "Type": "emptyDouble",
+                "ColumnNr": 14,
+                "RowNr": 14
+            },
+            {
+                "Category": "regular",
+                "Type": "double",
+                "ColumnNr": 15,
+                "RowNr": 14
+            },
+            {
+                "Category": "regular",
+                "Type": "emptyDouble",
+                "ColumnNr": 16,
+                "RowNr": 14
+            },
+            {
+                "Category": "regular",
+                "Type": "double",
+                "ColumnNr": 17,
+                "RowNr": 14
+            },
+            {
+                "Category": "regular",
+                "Type": "emptyDouble",
+                "ColumnNr": 18,
+                "RowNr": 14
+            },
+            {
+                "Category": "regular",
+                "Type": "double",
+                "ColumnNr": 19,
+                "RowNr": 14
+            },
+            {
+                "Category": "regular",
+                "Type": "emptyDouble",
+                "ColumnNr": 20,
+                "RowNr": 14
+            },
+            {
+                "Category": "regular",
+                "Type": "double",
+                "ColumnNr": 21,
+                "RowNr": 14
+            },
+            {
+                "Category": "regular",
+                "Type": "emptyDouble",
+                "ColumnNr": 22,
+                "RowNr": 14
+            }
+        ]
+    ]
+}


### PR DESCRIPTION
drastically reduce the response time by implementing a uuid wrapper, thereby allowing to use .MODELS() in jet insert queries, so a single request can be made to the database instead of one per entity (e.g. seat)

create cinema hall: 16s -> 0.2s
create event: 16s -> 0.4s

the tests for the sped up methods have not been modified yet, the rest is working according to the test. please test your endpoints with real data/requests though


