### PR TITLE
Allow more verbose kts_errors

### DIFF
--- a/src/handlers/user_handler.go
+++ b/src/handlers/user_handler.go
@@ -96,7 +96,7 @@ func CheckEmailHandler(userCtrl controllers.UserControllerI) gin.HandlerFunc {
 			return
 		}
 		if utils.ContainsEmptyString(requestData.Email) {
-			utils.HandleErrorAndAbort(c, kts_errors.KTS_BAD_REQUEST)
+			utils.HandleErrorAndAbort(c, kts_errors.KTS_BAD_REQUEST.WithDetails("Email is empty"))
 			return
 		}
 

--- a/src/handlers/user_handler_test.go
+++ b/src/handlers/user_handler_test.go
@@ -304,8 +304,9 @@ func TestCheckEmail(t *testing.T) {
 			name:            "Malformatted data",
 			body:            map[string]string{},
 			setExpectations: func(mockController *mocks.MockUserControllerI) {},
-			expectedResponseBody: gin.H{
-				"errorMessage": "BAD_REQUEST",
+			expectedResponseBody: models.KTSError{
+				KTSErrorMessage: models.KTSErrorMessage{ErrorMessage: "BAD_REQUEST"},
+				Details:         "Email is empty",
 			},
 			expectedStatus: http.StatusBadRequest,
 		},
@@ -313,8 +314,9 @@ func TestCheckEmail(t *testing.T) {
 			name:            "No data",
 			body:            nil,
 			setExpectations: func(mockController *mocks.MockUserControllerI) {},
-			expectedResponseBody: gin.H{
-				"errorMessage": "BAD_REQUEST",
+			expectedResponseBody: models.KTSError{
+				KTSErrorMessage: models.KTSErrorMessage{ErrorMessage: "BAD_REQUEST"},
+				Details:         "Email is empty",
 			},
 			expectedStatus: http.StatusBadRequest,
 		},

--- a/src/models/kts_error.go
+++ b/src/models/kts_error.go
@@ -6,5 +6,13 @@ type KTSErrorMessage struct {
 
 type KTSError struct {
 	KTSErrorMessage
-	Status int
+	Status  int   `json:"-"`
+	Details string `json:"details,omitempty"`
+}
+
+func (err *KTSError) WithDetails(details string) *KTSError {
+	newErr := new(KTSError)
+	*newErr = *err
+	newErr.Details = details
+	return newErr
 }

--- a/src/utils/errorutils.go
+++ b/src/utils/errorutils.go
@@ -8,6 +8,6 @@ import (
 )
 
 func HandleErrorAndAbort(c *gin.Context, err *models.KTSError) {
-	log.Printf("Error while handling request: %v", *err)
-	c.AbortWithStatusJSON(err.Status, err.KTSErrorMessage)
+	log.Printf("Error while handling request: %d %v %v", err.Status, err.ErrorMessage, err.Details)
+	c.AbortWithStatusJSON(err.Status, err)
 }


### PR DESCRIPTION
added an optional detail field in kts_errors for more verbose errors
when no detail string is specified, the behavior remains the same it is now (tests all pass)

example usage can be found in this pr

feel free to add the details in your routes